### PR TITLE
[16.0][IMP] stock_location_orderpoint: update replenishment date method to include orderpoint parameter

### DIFF
--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -449,7 +449,7 @@ class StockLocationOrderpoint(models.Model):
             for product, qty in qties_to_replenish:
                 date_planned = moves_by_location[
                     orderpoint.location_id
-                ]._get_location_orderpoint_replenishment_date(product)
+                ]._get_location_orderpoint_replenishment_date(product, orderpoint)
                 procurements.append(
                     orderpoint._prepare_procurement(
                         product, qty, date_planned, proc_vals

--- a/stock_location_orderpoint/models/stock_move.py
+++ b/stock_location_orderpoint/models/stock_move.py
@@ -16,7 +16,7 @@ class StockMove(models.Model):
     )
 
     @ormcache("self", "product")
-    def _get_location_orderpoint_replenishment_date(self, product):
+    def _get_location_orderpoint_replenishment_date(self, product, orderpoint):
         return min(
             self.filtered(lambda move: move.product_id == product).mapped("date")
         )


### PR DESCRIPTION
In some cases, we need to get access to the orderpoint when computing the date.