### PR TITLE
[16.0][IMP] stock_location_orderpoint: returns the ongoing replenishment moves.

### DIFF
--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -466,15 +466,17 @@ class StockLocationOrderpoint(models.Model):
     def run_replenishment(self, products=False):
         """Run the replenishment for all potential products or only a selection"""
         procurements = self._prepare_procurements(products)
-        if not procurements:
-            return
-        self.env["procurement.group"].with_context(from_orderpoint=True).run(
-            procurements, raise_user_error=False
-        )
-        self._after_replenishment()
+        if procurements:
+            self.env["procurement.group"].with_context(from_orderpoint=True).run(
+                procurements, raise_user_error=False
+            )
+        return self._after_replenishment()
 
-    def _get_generated_replenishment_moves_domain(self):
-        """Returns a domain which selects moves created by a replenishment"""
+    def _get_current_replenishment_moves_domain(self):
+        """
+        Returns a domain which selects ongoing replenishment moves created
+        or updated by the given orderpoints.
+        """
         domain = [
             ("state", "in", ["confirmed", "partially_available", "assigned"]),
             ("procure_method", "=", "make_to_stock"),
@@ -489,15 +491,18 @@ class StockLocationOrderpoint(models.Model):
         return moves_to_assign
 
     def _after_replenishment(self):
-        """Assigns generated replenishment moves and return them."""
-        generated_moves_domain = self._get_generated_replenishment_moves_domain()
-        generated_moves = self.env["stock.move"].search(
-            generated_moves_domain, order="priority desc, date asc, id asc"
+        """
+        Assigns generated replenishment moves and return all ongoing
+        moves for the given orderpoints.
+        """
+        current_moves_domain = self._get_current_replenishment_moves_domain()
+        current_moves = self.env["stock.move"].search(
+            current_moves_domain, order="priority desc, date asc, id asc"
         )
         self._assign_replenishment_moves(
-            generated_moves.filtered(lambda m: m.state != "assigned")
+            current_moves.filtered(lambda m: m.state != "assigned")
         )
-        return generated_moves
+        return current_moves
 
     def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -470,19 +470,23 @@ class StockLocationOrderpoint(models.Model):
             self.env["procurement.group"].with_context(from_orderpoint=True).run(
                 procurements, raise_user_error=False
             )
-        return self._after_replenishment()
+        replenishment_moves = self._get_current_replenishment_moves()
+        self._after_replenishment(replenishment_moves)
+        return replenishment_moves
 
-    def _get_current_replenishment_moves_domain(self):
+    def _get_current_replenishment_moves(self):
         """
-        Returns a domain which selects ongoing replenishment moves created
-        or updated by the given orderpoints.
+        Returns ongoing replenishment moves created or updated by the
+        given orderpoints.
         """
         domain = [
             ("state", "in", ["confirmed", "partially_available", "assigned"]),
             ("procure_method", "=", "make_to_stock"),
             ("location_orderpoint_id", "in", self.ids),
         ]
-        return domain
+        return self.env["stock.move"].search(
+            domain, order="priority desc, date asc, id asc"
+        )
 
     def _assign_replenishment_moves(self, moves_to_assign):
         """Assigns moves created by the orderpoints"""
@@ -490,19 +494,13 @@ class StockLocationOrderpoint(models.Model):
             self.env["stock.move"].browse(moves_chunk)._action_assign()
         return moves_to_assign
 
-    def _after_replenishment(self):
+    def _after_replenishment(self, replenishment_moves):
         """
-        Assigns generated replenishment moves and return all ongoing
-        moves for the given orderpoints.
+        Assigns generated replenishment moves.
         """
-        current_moves_domain = self._get_current_replenishment_moves_domain()
-        current_moves = self.env["stock.move"].search(
-            current_moves_domain, order="priority desc, date asc, id asc"
-        )
         self._assign_replenishment_moves(
-            current_moves.filtered(lambda m: m.state != "assigned")
+            replenishment_moves.filtered(lambda m: m.state != "assigned")
         )
-        return current_moves
 
     def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -473,26 +473,31 @@ class StockLocationOrderpoint(models.Model):
         )
         self._after_replenishment()
 
-    def _prepare_to_assign_replenishment_move_domain(self):
+    def _get_generated_replenishment_moves_domain(self):
         """Returns a domain which selects moves created by a replenishment"""
         domain = [
-            ("state", "in", ["confirmed", "partially_available"]),
+            ("state", "in", ["confirmed", "partially_available", "assigned"]),
             ("procure_method", "=", "make_to_stock"),
             ("location_orderpoint_id", "in", self.ids),
         ]
         return domain
 
-    def _assign_replenishment_moves(self):
+    def _assign_replenishment_moves(self, moves_to_assign):
         """Assigns moves created by the orderpoints"""
-        domain = self._prepare_to_assign_replenishment_move_domain()
-        moves_to_assign = self.env["stock.move"].search(
-            domain, order="priority desc, date asc, id asc"
-        )
         for moves_chunk in split_every(100, moves_to_assign.ids):
             self.env["stock.move"].browse(moves_chunk)._action_assign()
+        return moves_to_assign
 
     def _after_replenishment(self):
-        self._assign_replenishment_moves()
+        """Assigns generated replenishment moves and return them."""
+        generated_moves_domain = self._get_generated_replenishment_moves_domain()
+        generated_moves = self.env["stock.move"].search(
+            generated_moves_domain, order="priority desc, date asc, id asc"
+        )
+        self._assign_replenishment_moves(
+            generated_moves.filtered(lambda m: m.state != "assigned")
+        )
+        return generated_moves
 
     def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """

--- a/stock_location_orderpoint/tests/test_location_orderpoint.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint.py
@@ -9,6 +9,7 @@ from psycopg2 import IntegrityError
 from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tools import mute_logger
+from odoo.tools.date_utils import get_timedelta
 
 from odoo.addons.queue_job.job import identity_exact
 from odoo.addons.queue_job.tests.common import trap_jobs
@@ -96,12 +97,12 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
         self.assertFalse(replenish_move)
 
         # create the available quantity -> replenishment
-        tomorrow = now.replace(day=now.day + 1)
+        tomorrow = now + get_timedelta(1, "day")
         with self._freeze_time(tomorrow):
             self._set_qty_in_location(self.product, location_src, 12)
 
         self.product.invalidate_recordset()
-        day_after_tomorrow = tomorrow.replace(day=tomorrow.day + 1)
+        day_after_tomorrow = now + get_timedelta(2, "day")
         with self._freeze_time(day_after_tomorrow):
             cron.method_direct_trigger()
 


### PR DESCRIPTION
Make sure the replenishment method always returns its ongoing replenishment moves.

This is useful in case we want to add custom logic to the generated/updated replenishment moves. If the moves get returned, we do not need to make a second query to gather them afterwards.

This PR is based on #54 