### PR TITLE
[FIX] stock_location_orderpoint: fix migration script

### DIFF
--- a/stock_location_orderpoint/migrations/16.0.1.1.1/post-migrate.py
+++ b/stock_location_orderpoint/migrations/16.0.1.1.1/post-migrate.py
@@ -6,5 +6,5 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(
-        env.cr, "stock_location_orderpoint", "data/queue_job_function.xml", mode="init"
+        env, "stock_location_orderpoint", "data/queue_job_function.xml", mode="init"
     )


### PR DESCRIPTION
since 17.0, `openupgrade.load_data` only accepts `env` as a first arg (used to be env or cr)