### PR TITLE
 [FIX] stock_location_orderpoint: fix date dependend test.

### DIFF
--- a/stock_location_orderpoint/tests/test_location_orderpoint.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint.py
@@ -9,6 +9,7 @@ from psycopg2 import IntegrityError
 from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tools import mute_logger
+from odoo.tools.date_utils import get_timedelta
 
 from odoo.addons.queue_job.job import identity_exact
 from odoo.addons.queue_job.tests.common import trap_jobs
@@ -96,12 +97,12 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
         self.assertFalse(replenish_move)
 
         # create the available quantity -> replenishment
-        tomorrow = now.replace(day=now.day + 1)
+        tomorrow = now + get_timedelta(1, "day")
         with self._freeze_time(tomorrow):
             self._set_qty_in_location(self.product, location_src, 12)
 
         self.product.invalidate_recordset()
-        day_after_tomorrow = tomorrow.replace(day=tomorrow.day + 1)
+        day_after_tomorrow = now + get_timedelta(2, "day")
         with self._freeze_time(day_after_tomorrow):
             cron.method_direct_trigger()
 


### PR DESCRIPTION
Some test was failing because the code saying "day +1" fails if we are the last day of a month.