### PR TITLE
[18.0][FIX] stock_location_orderpoint: trigger auto replenishment

### DIFF
--- a/stock_location_orderpoint/__manifest__.py
+++ b/stock_location_orderpoint/__manifest__.py
@@ -29,6 +29,6 @@
         "queue_job",
     ],
     "license": "AGPL-3",
-    "maintainers": ["mt-software-de"],
+    "maintainers": ["mt-software-de", "jbaudoux"],
     "website": "https://github.com/OCA/stock-logistics-orderpoint",
 }

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from collections import defaultdict
 from copy import copy
@@ -240,7 +241,6 @@ class StockLocationOrderpoint(models.Model):
         the location"""
         domain = [
             ("move_dest_ids", "=", False),
-            ("procure_method", "=", "make_to_stock"),
             ("state", "=", "done"),
         ]
         if self:


### PR DESCRIPTION
When a done move changes the stock of a location that is a source location of an orderpoint, the procure method of that done move does not matter