### PR TITLE
[16.0][IMP] stock_orderpoint_mto_as_mts: perf & categ + fix mrp + add hook

### DIFF
--- a/stock_orderpoint_mto_as_mts/__manifest__.py
+++ b/stock_orderpoint_mto_as_mts/__manifest__.py
@@ -4,7 +4,6 @@
     "name": "Stock Orderpoint Mto As Mts",
     "summary": "Materialize need from MTO route through orderpoint",
     "version": "16.0.1.1.0",
-    "development_status": "Alpha",
     "category": "Operations/Inventory/Delivery",
     "website": "https://github.com/OCA/stock-logistics-orderpoint",
     "author": "BCIM, Camptocamp, Odoo Community Association (OCA)",

--- a/stock_orderpoint_mto_as_mts/models/product_category.py
+++ b/stock_orderpoint_mto_as_mts/models/product_category.py
@@ -1,34 +1,70 @@
 # Copyright 2024 Camptocamp SA
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-from odoo import fields, models
+import logging
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
 
 
 class ProductCategory(models.Model):
     _inherit = "product.category"
 
-    product_ids = fields.One2many("product.product", "categ_id", string="Products")
-
     def write(self, vals):
-        # Override this method to update order points for MTO / not MTO products
-        # that linked to these categories
+        if not self or not ("route_ids" in vals or "parent_id" in vals):
+            return super().write(vals)
 
-        if not vals.get("route_ids", False):
-            # No changes for MTO routes, so no changes for is_mto on products
-            res = super().write(vals)
-            self.product_ids.sudo()._ensure_default_orderpoint_for_mto()
-            return res
-
-        original_mto_products = self.product_ids.filtered(
-            lambda product: product.is_mto
+        categ_was_mto = self.filtered(
+            lambda c: any(route.is_mto for route in c.total_route_ids)
         )
-        res = super().write(vals)
-        self.product_ids.sudo()._ensure_default_orderpoint_for_mto()
+        if categ_was_mto:
+            # Load MTO products as we may need to archive them.
+            # A category is not bound to a company, search products accross all
+            # companies.
+            _logger.debug("Search products already as MTO")
+            original_mto_products = (
+                self.env["product.product"]
+                .sudo()
+                .search(
+                    [
+                        ("categ_id", "child_of", self.ids),
+                        ("is_mto", "=", True),
+                    ]
+                )
+            )
+        categ_was_not_mto = self - categ_was_mto
 
-        # Find all MTO products that have been changed to Not MTO
-        not_mto_product = self.product_ids.filtered(lambda product: not product.is_mto)
-        product_to_update = original_mto_products & not_mto_product
-        if product_to_update:
-            # Archive order points
-            product_to_update._archive_orderpoints_on_mto_removal()
+        res = super().write(vals)
+
+        self.invalidate_recordset(["total_route_ids"])
+        categ_is_mto = self.filtered(
+            lambda c: any(route.is_mto for route in self.total_route_ids)
+        )
+        categ_is_not_mto = self - categ_is_mto
+        categ_changed_to_mto = categ_was_not_mto & categ_is_mto
+        categ_changed_to_not_mto = categ_was_mto & categ_is_not_mto
+        # Update orderpoints for MTO / not MTO products that are linked to
+        # these categories.
+        if categ_changed_to_mto:
+            # Update all products to prevent recompute one by one
+            # A category is not bound to a company, search products accross all
+            # companies.
+            _logger.debug("Search products to mark as MTO")
+            products = (
+                self.env["product.product"]
+                .sudo()
+                .search([("categ_id", "child_of", categ_changed_to_mto.ids)])
+            )
+            not_mto_products = products.search(
+                [("id", "in", products.ids), ("is_mto", "=", False)]
+            )
+            _logger.debug(f"Mark {len(not_mto_products)} products as MTO")
+            not_mto_products.with_context(orderpoint_mto_as_mts=True).is_mto = True
+            _logger.debug("Marked")
+            # Populate missing orderpoints
+            products._ensure_default_orderpoint_for_mto()
+        if categ_changed_to_not_mto:
+            original_mto_products._archive_orderpoints_on_mto_removal()
         return res

--- a/stock_orderpoint_mto_as_mts/models/product_product.py
+++ b/stock_orderpoint_mto_as_mts/models/product_product.py
@@ -36,7 +36,14 @@ class ProductProduct(models.Model):
         )
         return vals
 
-    def _ensure_default_orderpoint_for_mto(self):
+    @property
+    @api.model
+    def _ensure_default_orderpoint_for_mto_domain(self):
+        return [
+            ("is_mto", "=", True),
+        ]
+
+    def _ensure_default_orderpoint_for_mto(self, domain=False, warehouse=False):
         """Ensure that a default orderpoint is created for the MTO products.
 
         Perform this on all product companies.
@@ -44,11 +51,13 @@ class ProductProduct(models.Model):
         if not self:
             return
         _logger.debug("Ensure orderpoint for MTO")
+        if domain is False:
+            domain = self._ensure_default_orderpoint_for_mto_domain
+        mto_domain = [
+            ("id", "in", self.ids),
+        ] + domain
         products_group = self._read_group(
-            domain=[
-                ("id", "in", self.ids),
-                ("is_mto", "=", True),
-            ],
+            domain=mto_domain,
             fields=["id", "company_id"],
             groupby=["company_id"],
         )
@@ -62,7 +71,10 @@ class ProductProduct(models.Model):
         wh_obj = self.env["stock.warehouse"]
         op_obj = self.env["stock.warehouse.orderpoint"]
         orderpoint_vals_base = self._prepare_orderpoint_vals_base()
-        all_mto_wh = wh_obj.search([("mto_as_mts", "=", True)])
+        if warehouse:
+            all_mto_wh = warehouse.filtered("mto_as_mts")
+        else:
+            all_mto_wh = wh_obj.search([("mto_as_mts", "=", True)])
         all_mto_wh_by_company = defaultdict(list)
         for record in all_mto_wh:
             all_mto_wh_by_company[record.company_id].extend(record)

--- a/stock_orderpoint_mto_as_mts/models/product_product.py
+++ b/stock_orderpoint_mto_as_mts/models/product_product.py
@@ -1,54 +1,19 @@
 # Copyright 2023 ACSONE SA/NV
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import logging
+from collections import defaultdict
+
 from odoo import api, models
+from odoo.tools import split_every
+
+_logger = logging.getLogger(__name__)
 
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
-
-    def _get_warehouse_missing_orderpoint_for_mto(self):
-        self.ensure_one()
-        res = False
-        if not self.purchase_ok:
-            return res
-        wh_obj = self.env["stock.warehouse"]
-        wh_domain = [("mto_as_mts", "=", True)]
-        if self.company_id:
-            wh_domain.append(("company_id", "=", self.company_id.id))
-        wh = wh_obj.search(wh_domain)
-        wh_orderpoint = self.orderpoint_ids.warehouse_id
-        wh_wo_orderpoint = wh - wh_orderpoint
-        if wh_wo_orderpoint:
-            res = wh_wo_orderpoint
-        return res
-
-    def _create_default_orderpoint_for_mto(self, warehouses):
-        self.ensure_one()
-        orderpoints = self.env["stock.warehouse.orderpoint"]
-        orderpoint_obj = self.env["stock.warehouse.orderpoint"]
-        orderpoint_vals_base = self._prepare_orderpoint_vals_base()
-        for warehouse in warehouses:
-            orderpoint = orderpoint_obj.with_context(active_test=False).search(
-                [
-                    ("product_id", "=", self.id),
-                    (
-                        "location_id",
-                        "=",
-                        warehouse._get_locations_for_mto_orderpoints().id,
-                    ),
-                ],
-                limit=1,
-                order="id",
-            )
-            if orderpoint and not orderpoint.active:
-                orderpoint.write(orderpoint_vals_base)
-            elif not orderpoint:
-                vals = self._prepare_missing_orderpoint_vals(warehouse)
-                orderpoint = orderpoint_obj.create(vals)
-            orderpoints |= orderpoint
-        return orderpoints
 
     @api.model
     def _prepare_orderpoint_vals_base(self):
@@ -60,15 +25,13 @@ class ProductProduct(models.Model):
         }
 
     def _prepare_missing_orderpoint_vals(self, warehouse):
-        self.ensure_one()
         vals = self._prepare_orderpoint_vals_base()
         vals.update(
             {
+                "name": "MTO",  # give a name as next_by_code is too slow for large data
                 "warehouse_id": warehouse.id,
                 "product_id": self.id,
                 "company_id": warehouse.company_id.id,
-                "location_id": warehouse._get_locations_for_mto_orderpoints().id,
-                "product_uom": self.uom_id.id,
             }
         )
         return vals
@@ -76,42 +39,121 @@ class ProductProduct(models.Model):
     def _ensure_default_orderpoint_for_mto(self):
         """Ensure that a default orderpoint is created for the MTO products.
 
-        that have no orderpoint yet.
+        Perform this on all product companies.
         """
-        for product in self.filtered(lambda p: p.is_mto):
-            wh = product._get_warehouse_missing_orderpoint_for_mto()
-            if wh:
-                product._create_default_orderpoint_for_mto(wh)
+        if not self:
+            return
+        _logger.debug("Ensure orderpoint for MTO")
+        products_group = self._read_group(
+            domain=[
+                ("id", "in", self.ids),
+                ("is_mto", "=", True),
+                ("purchase_ok", "=", True),
+            ],
+            fields=["id", "company_id"],
+            groupby=["company_id"],
+        )
+        if not products_group:
+            return
+        products_by_company = list()
+        for group in products_group:
+            products_by_company.append(
+                (group["company_id"], self.search(group["__domain"]))
+            )
+        wh_obj = self.env["stock.warehouse"]
+        op_obj = self.env["stock.warehouse.orderpoint"]
+        orderpoint_vals_base = self._prepare_orderpoint_vals_base()
+        all_mto_wh = wh_obj.search([("mto_as_mts", "=", True)])
+        all_mto_wh_by_company = defaultdict(list)
+        for record in all_mto_wh:
+            all_mto_wh_by_company[record.company_id].extend(record)
+        op_vals_list = []
+        for company, products in products_by_company:
+            if company:
+                mto_wh = all_mto_wh_by_company.get(company)
+            else:
+                mto_wh = all_mto_wh
+            if not mto_wh:
+                continue
+            locations = self.env["stock.location"].browse()
+            for wh in mto_wh:
+                locations |= wh._get_locations_for_mto_orderpoints()
+            # Reactivate inactive orderpoints
+            inactive_ops = op_obj.with_context(active_test=False).search(
+                [
+                    ("active", "=", False),
+                    ("location_id", "in", locations.ids),
+                    ("product_id", "in", products.ids),
+                ]
+            )
+            if inactive_ops:
+                inactive_ops.write(orderpoint_vals_base)
+            # Find products having an orderpoint for that wh
+            # Prepare missing orderpoints
+            for warehouse in mto_wh:
+                _logger.debug(f"Prepare orderpoint for warehouse {warehouse.name}")
+                products_for_wh = op_obj.search(
+                    domain=[
+                        ("product_id", "in", products.ids),
+                        ("warehouse_id", "in", warehouse.ids),
+                    ],
+                ).product_id
+                missing_products = products - products_for_wh
+                for product in missing_products:
+                    op_vals_list.append(
+                        product._prepare_missing_orderpoint_vals(warehouse)
+                    )
+        chunk_size = models.INSERT_BATCH_SIZE * 20
+        _logger.debug(
+            f"Create orderpoint for MTO: {len(op_vals_list)} to create - "
+            f"{len(op_vals_list) // chunk_size + 1} chunks"
+        )
+        for i, op_vals_list_chunk in enumerate(split_every(chunk_size, op_vals_list)):
+            _logger.debug(f"Create orderpoint for MTO - chunk {i}")
+            ops = op_obj.create(op_vals_list_chunk)
+            # free memory usage
+            ops.invalidate_model()
 
     @api.model_create_multi
     def create(self, vals_list):
         products = super().create(vals_list)
-        products.sudo()._ensure_default_orderpoint_for_mto()
+        products._ensure_default_orderpoint_for_mto()
         return products
 
-    def _get_orderpoints_to_archive_domain(self):
+    def _get_orderpoints_to_archive_domain(self, warehouses):
         domain = []
-        warehouses = self.env["stock.warehouse"].search(
-            [("mto_as_mts", "=", True), ("archive_orderpoints_mto_removal", "=", True)]
+        locations = self.env["stock.location"]
+        for warehouse in warehouses:
+            locations |= warehouse._get_locations_for_mto_orderpoints()
+        domain.extend(
+            [
+                ("product_id", "in", self.ids),
+                ("product_min_qty", "=", 0.0),
+                ("product_max_qty", "=", 0.0),
+                ("location_id", "in", locations.ids),
+                ("trigger", "=", "auto"),
+            ]
         )
-        if warehouses:
-            locations = self.env["stock.location"]
-            for warehouse in warehouses:
-                locations |= warehouse._get_locations_for_mto_orderpoints()
-            domain.extend(
-                [
-                    ("product_id", "in", self.ids),
-                    ("product_min_qty", "=", 0.0),
-                    ("product_max_qty", "=", 0.0),
-                    ("location_id", "in", locations.ids),
-                    ("trigger", "=", "auto"),
-                ]
-            )
         return domain
 
-    def _archive_orderpoints_on_mto_removal(self):
-        domain = self._get_orderpoints_to_archive_domain()
-        if domain:
-            ops = self.env["stock.warehouse.orderpoint"].search(domain)
-            if ops:
-                ops.write({"active": False})
+    def _archive_orderpoints_on_mto_removal(self, forceall=False):
+        if not self:
+            return
+        warehouses = self.env["stock.warehouse"].search(
+            [
+                ("mto_as_mts", "=", True),
+                ("archive_orderpoints_mto_removal", "=", True),
+            ]
+        )
+        if not warehouses:
+            return
+        if not forceall:
+            self = self.filtered(lambda p: not p.is_mto)
+        if not self:
+            return
+        domain = self._get_orderpoints_to_archive_domain(warehouses)
+        if not domain:
+            return
+        ops = self.env["stock.warehouse.orderpoint"].search(domain)
+        if ops:
+            ops.write({"active": False})

--- a/stock_orderpoint_mto_as_mts/models/product_product.py
+++ b/stock_orderpoint_mto_as_mts/models/product_product.py
@@ -48,7 +48,6 @@ class ProductProduct(models.Model):
             domain=[
                 ("id", "in", self.ids),
                 ("is_mto", "=", True),
-                ("purchase_ok", "=", True),
             ],
             fields=["id", "company_id"],
             groupby=["company_id"],
@@ -75,6 +74,8 @@ class ProductProduct(models.Model):
                 mto_wh = all_mto_wh
             if not mto_wh:
                 continue
+            if hasattr(self.browse(), "is_kits"):  # mrp forbid orderpoint for kits
+                products = products.filtered(lambda p: not p.is_kits)
             locations = self.env["stock.location"].browse()
             for wh in mto_wh:
                 locations |= wh._get_locations_for_mto_orderpoints()

--- a/stock_orderpoint_mto_as_mts/models/product_template.py
+++ b/stock_orderpoint_mto_as_mts/models/product_template.py
@@ -1,4 +1,4 @@
-# Copyright 2024
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, models
@@ -10,31 +10,24 @@ class ProductTemplate(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         template = super().create(vals_list)
-        template.product_variant_ids.sudo()._ensure_default_orderpoint_for_mto()
+        template.product_variant_ids._ensure_default_orderpoint_for_mto()
         return template
 
     def write(self, vals):
-        original_mto_templates = self.filtered(lambda temp: temp.is_mto)
+        if self.env.context.get("orderpoint_mto_as_mts"):
+            return super().write(vals)
+        if "route_ids" in vals or "categ_id" in vals:
+            original_mto_products = self.product_variant_ids.filtered("is_mto")
         res = super().write(vals)
-        self.product_variant_ids.sudo()._ensure_default_orderpoint_for_mto()
-        self._update_mto_templates(original_mto_templates, vals)
-        return res
-
-    def _update_mto_templates(self, original_mto_templates, vals):
         if "company_id" in vals:
             # Change company, must archive orderpoints
-            self.product_variant_ids.sudo()._archive_orderpoints_on_mto_removal()
-            self.product_variant_ids.sudo()._ensure_default_orderpoint_for_mto()
-            return
-        elif "route_ids" not in vals and "categ_id" not in vals:
-            # No changes about is_mto
-            self.product_variant_ids.sudo()._ensure_default_orderpoint_for_mto()
-            return
-
-        not_mto_templates = self.filtered(lambda temp: not temp.is_mto)
-        # Find all MTO templates that have been changed to Not MTO
-        templates_to_update = original_mto_templates & not_mto_templates
-        if templates_to_update:
-            # Archive order points
-            templates_to_update.product_variant_ids._archive_orderpoints_on_mto_removal()
-        return
+            self.product_variant_ids.sudo()._archive_orderpoints_on_mto_removal(
+                forceall=True
+            )
+            self.product_variant_ids._ensure_default_orderpoint_for_mto()
+        elif "route_ids" in vals or "categ_id" in vals:
+            # is_mto may have changed
+            original_mto_products._archive_orderpoints_on_mto_removal()
+            original_not_mto_products = self.product_variant_ids - original_mto_products
+            original_not_mto_products._ensure_default_orderpoint_for_mto()
+        return res

--- a/stock_orderpoint_mto_as_mts/models/stock_route.py
+++ b/stock_orderpoint_mto_as_mts/models/stock_route.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Camptocamp SA
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo import models
@@ -8,31 +9,20 @@ class StockRoute(models.Model):
     _inherit = "stock.route"
 
     def write(self, vals):
-        # Override this method to update order points for MTO / not MTO products
-        # that linked to these routes
-
         if "is_mto" not in vals:
-            # No changes for is_mto, so no changes for is_mto on products
-            res = super().write(vals)
-            (
-                self.product_ids.product_variant_ids | self.categ_ids.product_ids
-            ).sudo()._ensure_default_orderpoint_for_mto()
-            return res
-
-        original_mto_products = (
-            self.product_ids.product_variant_ids | self.categ_ids.product_ids
-        ).filtered(lambda product: product.is_mto)
-        res = super().write(vals)
-
-        linked_products = (
-            self.product_ids.product_variant_ids | self.categ_ids.product_ids
+            return super().write(vals)
+        products = self.product_ids.product_variant_ids
+        products |= self.env["product.product"].search(
+            [("categ_id", "child_of", self.categ_ids.ids)]
         )
-        linked_products.sudo()._ensure_default_orderpoint_for_mto()
-        # Find all MTO products that have been changed to Not MTO
-        not_mto_product = linked_products.filtered(lambda product: not product.is_mto)
-        product_to_update = original_mto_products & not_mto_product
-
-        if product_to_update:
-            # Archive order points
-            product_to_update._archive_orderpoints_on_mto_removal()
+        res = super().write(vals)
+        # The set of products may have changed after write
+        products |= self.product_ids.product_variant_ids
+        products |= self.env["product.product"].search(
+            [("categ_id", "child_of", self.categ_ids.ids)]
+        )
+        if vals["is_mto"]:
+            products._ensure_default_orderpoint_for_mto()
+        else:
+            products._archive_orderpoints_on_mto_removal()
         return res

--- a/stock_orderpoint_mto_as_mts/tests/test_stock_orderpoint_mto_as_mts.py
+++ b/stock_orderpoint_mto_as_mts/tests/test_stock_orderpoint_mto_as_mts.py
@@ -46,7 +46,7 @@ class TestStockOrderpointMtoAsMts(common.TransactionCase):
             [("product_id", "=", product.id)]
         )
         self.assertTrue(orderpoints)
-        self.assertTrue(len(orderpoints) == 2)
+        self.assertEqual(len(orderpoints), 2)
         # Ensure orderpoints are created with correct values
         orderpoint = orderpoints[0]
         self.assertEqual(orderpoint.product_min_qty, 0)
@@ -72,7 +72,7 @@ class TestStockOrderpointMtoAsMts(common.TransactionCase):
             [("product_id", "=", product.id)]
         )
         self.assertTrue(orderpoint)
-        self.assertTrue(len(orderpoint) == 2)
+        self.assertEqual(len(orderpoint), 2)
         # Change company
         product.write(
             {"company_id": self.env["res.company"].create({"name": "New Company"}).id}
@@ -102,7 +102,7 @@ class TestStockOrderpointMtoAsMts(common.TransactionCase):
             [("product_id", "=", product.id)]
         )
         self.assertTrue(orderpoint)
-        self.assertTrue(len(orderpoint) == 2)
+        self.assertEqual(len(orderpoint), 2)
 
     def test_orderpoint_when_changing_is_mto_on_routes(self):
         # Reset is MTO on route
@@ -131,7 +131,7 @@ class TestStockOrderpointMtoAsMts(common.TransactionCase):
             [("product_id", "=", product.id)]
         )
         self.assertTrue(orderpoint)
-        self.assertTrue(len(orderpoint) == 2)
+        self.assertEqual(len(orderpoint), 2)
 
         # Check case: Enable is_mto on route that has been linked to product category
         self.mto_route.is_mto = False  # Reset is MTO on route
@@ -154,7 +154,7 @@ class TestStockOrderpointMtoAsMts(common.TransactionCase):
             [("product_id", "=", product.id)]
         )
         self.assertTrue(orderpoint)
-        self.assertTrue(len(orderpoint) == 2)
+        self.assertEqual(len(orderpoint), 2)
 
     def test_orderpoint_with_template(self):
         # Create a template with 3 variants
@@ -201,7 +201,7 @@ class TestStockOrderpointMtoAsMts(common.TransactionCase):
             [("product_id", "in", product_template_sofa.product_variant_ids.ids)]
         )
         self.assertTrue(orderpoint)
-        self.assertTrue(len(orderpoint) == 6)
+        self.assertEqual(len(orderpoint), 6)
         # Archive orderpoint
         product_template_sofa.write({"route_ids": [(6, 0, [])]})
         orderpoint = self.env["stock.warehouse.orderpoint"].search(

--- a/stock_orderpoint_mto_as_mts/tests/test_stock_warehouse_mto_as_mts.py
+++ b/stock_orderpoint_mto_as_mts/tests/test_stock_warehouse_mto_as_mts.py
@@ -8,7 +8,6 @@ class TestStockWareHouseMtoAsMts(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
 
         cls.warehouse = cls.env.ref("stock.warehouse0")
         cls.warehouse1 = cls.env["stock.warehouse"].create(


### PR DESCRIPTION
Backport improvements from v18.0 that were part of
* https://github.com/OCA/stock-logistics-orderpoint/pull/39

Improve performace on each product create/write
Fix the route on the category as it is propagated to children categories

In case mrp is installed, exclude orderpoints on kits as it is forbidden
Remove filtering on purchase_ok as it's not handled when the value is changed and the product could also be manufactured

Add hooks to product domain and applicability warehouse

Removed Alpha state