### PR TITLE
[16.0][IMP] stock_orderpoint_mto_as_mto: trigger auto/manual

### DIFF
--- a/stock_orderpoint_mto_as_mts/models/product_product.py
+++ b/stock_orderpoint_mto_as_mts/models/product_product.py
@@ -16,16 +16,17 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     @api.model
-    def _prepare_orderpoint_vals_base(self):
+    def _prepare_orderpoint_vals_base(self, warehouse=False):
+        trigger = warehouse and warehouse.mto_orderpoint_trigger or "auto"
         return {
             "active": True,
             "product_min_qty": 0,
             "product_max_qty": 0,
-            "trigger": "auto",
+            "trigger": trigger,
         }
 
     def _prepare_missing_orderpoint_vals(self, warehouse):
-        vals = self._prepare_orderpoint_vals_base()
+        vals = self._prepare_orderpoint_vals_base(warehouse)
         vals.update(
             {
                 "name": "MTO",  # give a name as next_by_code is too slow for large data

--- a/stock_orderpoint_mto_as_mts/models/stock_warehouse.py
+++ b/stock_orderpoint_mto_as_mts/models/stock_warehouse.py
@@ -7,7 +7,10 @@ class StockWarehouse(models.Model):
 
     _inherit = "stock.warehouse"
 
-    mto_as_mts = fields.Boolean(inverse="_inverse_mto_as_mts")
+    mto_as_mts = fields.Boolean(
+        inverse="_inverse_mto_as_mts",
+        help="Manage MTO by orderpoint",
+    )
     archive_orderpoints_mto_removal = fields.Boolean(default=False)
 
     def _get_locations_for_mto_orderpoints(self):

--- a/stock_orderpoint_mto_as_mts/models/stock_warehouse.py
+++ b/stock_orderpoint_mto_as_mts/models/stock_warehouse.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp SA
+# Copyright 2026 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import fields, models
 
@@ -10,6 +11,12 @@ class StockWarehouse(models.Model):
     mto_as_mts = fields.Boolean(
         inverse="_inverse_mto_as_mts",
         help="Manage MTO by orderpoint",
+    )
+    mto_orderpoint_trigger = fields.Selection(
+        [("auto", "Auto"), ("manual", "Manual")],
+        default="auto",
+        help="Orderpoint trigger for any newly automaticaly created orderpoint. "
+        "Existing orderpoints need to be manually changed",
     )
     archive_orderpoints_mto_removal = fields.Boolean(default=False)
 

--- a/stock_orderpoint_mto_as_mts/readme/DESCRIPTION.rst
+++ b/stock_orderpoint_mto_as_mts/readme/DESCRIPTION.rst
@@ -4,3 +4,4 @@ an orderpoint in the procurement of MTO products.
 The MTO route will loose it's MTO rule as this is replaced by the generated orderpoints.
 When a product is configured as MTO, then an orderpoint with min/max of zero is created.
 When the product is not anymore configured as MTO, the orderpoint can be automatically archived depending on the configuration you choose on the warehouse.
+You can choose to generate orderpoints with an auto or manual trigger.

--- a/stock_orderpoint_mto_as_mts/tests/test_stock_orderpoint_mto_as_mts.py
+++ b/stock_orderpoint_mto_as_mts/tests/test_stock_orderpoint_mto_as_mts.py
@@ -59,6 +59,28 @@ class TestStockOrderpointMtoAsMts(common.TransactionCase):
         )
         self.assertFalse(orderpoint)
 
+    def test_orderpoint_manual(self):
+        self.warehouse.mto_orderpoint_trigger = "manual"
+        # Create orderpoint
+        product = self.env["product.product"].create(
+            {
+                "name": "Test MTO",
+                "type": "product",
+                "route_ids": [(6, 0, [self.mto_route.id])],
+            }
+        )
+        orderpoint = self.env["stock.warehouse.orderpoint"].search(
+            [
+                ("product_id", "=", product.id),
+                ("warehouse_id", "=", self.warehouse.id),
+            ]
+        )
+        self.assertEqual(len(orderpoint), 1)
+        # Ensure orderpoints are created with correct values
+        self.assertEqual(orderpoint.product_min_qty, 0)
+        self.assertEqual(orderpoint.product_max_qty, 0)
+        self.assertEqual(orderpoint.trigger, "manual")
+
     def test_orderpoint_when_changing_company(self):
         # Create orderpoint
         product = self.env["product.product"].create(

--- a/stock_orderpoint_mto_as_mts/views/stock_warehouse_views.xml
+++ b/stock_orderpoint_mto_as_mts/views/stock_warehouse_views.xml
@@ -8,6 +8,10 @@
             <field name="partner_id" position="after">
                 <field name="mto_as_mts" />
                 <field
+                    name="mto_orderpoint_trigger"
+                    attrs="{'required': [('mto_as_mts', '=', True)], 'invisible': [('mto_as_mts', '=', False)]}"
+                />
+                <field
                     name="archive_orderpoints_mto_removal"
                     attrs="{'invisible': [('mto_as_mts', '=', False)]}"
                 />

--- a/stock_orderpoint_mto_as_mts/views/stock_warehouse_views.xml
+++ b/stock_orderpoint_mto_as_mts/views/stock_warehouse_views.xml
@@ -7,7 +7,10 @@
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
                 <field name="mto_as_mts" />
-                <field name="archive_orderpoints_mto_removal" />
+                <field
+                    name="archive_orderpoints_mto_removal"
+                    attrs="{'invisible': [('mto_as_mts', '=', False)]}"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Allow to auto-generate orderpoints for MTO products with a manual or auto trigger. Before it was always auto

cc @nicolas-delbovier-acsone @mt-software-de