### PR TITLE
[16.0][FIX] sale_stock_orderpoint_mto_as_mts: run newly created orderpoints

### DIFF
--- a/sale_stock_orderpoint_mto_as_mts/models/sale_order_line.py
+++ b/sale_stock_orderpoint_mto_as_mts/models/sale_order_line.py
@@ -19,17 +19,31 @@ class SaleOrderLine(models.Model):
 
     def _ensure_default_orderpoints_for_mto(self):
         mto_products_by_wh = defaultdict(lambda: self.product_id.browse())
+        origins_by_wh_by_prod = defaultdict(lambda: defaultdict(list))
         for sol in self:
             for move in self.move_ids:
                 route = sol.route_id or move.rule_id.route_id
                 if (
                     route.is_mto
                     and move.picking_type_id.code == "outgoing"
-                    and move.state not in ("done", "cancel")
+                    and move.state not in ("draft", "done", "cancel")
                 ):
                     wh = move.warehouse_id or sol.order_id.warehouse_id
                     mto_products_by_wh[wh] |= move.product_id
+                    origins_by_wh_by_prod[wh][move.product_id].append(move.origin)
         for warehouse, mto_products in mto_products_by_wh.items():
-            mto_products._ensure_default_orderpoint_for_mto(
+            new_orderpoints = mto_products._ensure_default_orderpoint_for_mto(
                 domain=[], warehouse=warehouse
             )
+            # As orderpoint are created after the SO demand has been placed, we
+            # need to run them if they are in auto trigger
+            ops = new_orderpoints.filtered(lambda op: op.trigger == "auto")
+            if ops and not self.env["ir.config_parameter"].sudo().get_param(
+                "stock.no_auto_scheduler"
+            ):
+                origins = {
+                    op.id: origins_by_wh_by_prod[warehouse][op.product_id] for op in ops
+                }
+                ops.with_context(origins=origins)._procure_orderpoint_confirm(
+                    company_id=warehouse.company_id, raise_user_error=False
+                )

--- a/stock_orderpoint_mto_as_mts/models/product_product.py
+++ b/stock_orderpoint_mto_as_mts/models/product_product.py
@@ -79,6 +79,7 @@ class ProductProduct(models.Model):
         for record in all_mto_wh:
             all_mto_wh_by_company[record.company_id].extend(record)
         op_vals_list = []
+        all_orderpoints = op_obj.browse()
         for company, products in products_by_company:
             if company:
                 mto_wh = all_mto_wh_by_company.get(company)
@@ -101,6 +102,7 @@ class ProductProduct(models.Model):
             )
             if inactive_ops:
                 inactive_ops.write(orderpoint_vals_base)
+                all_orderpoints += inactive_ops
             # Find products having an orderpoint for that wh
             # Prepare missing orderpoints
             for warehouse in mto_wh:
@@ -124,8 +126,10 @@ class ProductProduct(models.Model):
         for i, op_vals_list_chunk in enumerate(split_every(chunk_size, op_vals_list)):
             _logger.debug(f"Create orderpoint for MTO - chunk {i}")
             ops = op_obj.create(op_vals_list_chunk)
+            all_orderpoints += ops
             # free memory usage
             ops.invalidate_model()
+        return all_orderpoints
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
As the creation of orderpoints occurs after the move demand is created, we need to run newly created orderpoint that are in auto trigger

cc @lmignon @nicolas-delbovier-acsone @mt-software-de 