### PR TITLE
[16.0] stock_location_orderpoint:  Correctly update replenishment move priority

### DIFF
--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -466,33 +466,43 @@ class StockLocationOrderpoint(models.Model):
     def run_replenishment(self, products=False):
         """Run the replenishment for all potential products or only a selection"""
         procurements = self._prepare_procurements(products)
-        if not procurements:
-            return
-        self.env["procurement.group"].with_context(from_orderpoint=True).run(
-            procurements, raise_user_error=False
-        )
-        self._after_replenishment()
+        if procurements:
+            self.env["procurement.group"].with_context(from_orderpoint=True).run(
+                procurements, raise_user_error=False
+            )
+        replenishment_moves = self._get_current_replenishment_moves(products)
+        self._after_replenishment(replenishment_moves)
+        return replenishment_moves
 
-    def _prepare_to_assign_replenishment_move_domain(self):
-        """Returns a domain which selects moves created by a replenishment"""
+    def _get_current_replenishment_moves(self, products=False):
+        """
+        Returns ongoing replenishment moves created or updated by the
+        given orderpoints.
+        """
         domain = [
-            ("state", "in", ["confirmed", "partially_available"]),
+            ("state", "in", ["confirmed", "partially_available", "assigned"]),
             ("procure_method", "=", "make_to_stock"),
             ("location_orderpoint_id", "in", self.ids),
         ]
-        return domain
-
-    def _assign_replenishment_moves(self):
-        """Assigns moves created by the orderpoints"""
-        domain = self._prepare_to_assign_replenishment_move_domain()
-        moves_to_assign = self.env["stock.move"].search(
+        if products:
+            domain = expression.AND([domain, [("product_id", "in", products.ids)]])
+        return self.env["stock.move"].search(
             domain, order="priority desc, date asc, id asc"
         )
+
+    def _assign_replenishment_moves(self, moves_to_assign):
+        """Assigns moves created by the orderpoints"""
         for moves_chunk in split_every(100, moves_to_assign.ids):
             self.env["stock.move"].browse(moves_chunk)._action_assign()
+        return moves_to_assign
 
-    def _after_replenishment(self):
-        self._assign_replenishment_moves()
+    def _after_replenishment(self, replenishment_moves):
+        """
+        Assigns generated replenishment moves.
+        """
+        self._assign_replenishment_moves(
+            replenishment_moves.filtered(lambda m: m.state != "assigned")
+        )
 
     def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -503,6 +503,12 @@ class StockLocationOrderpoint(models.Model):
         self._assign_replenishment_moves(
             replenishment_moves.filtered(lambda m: m.state != "assigned")
         )
+        for move in replenishment_moves.sudo():
+            new_priority = move.location_orderpoint_id.priority
+            if move.picking_id.priority != new_priority:
+                move.picking_id.priority = new_priority
+            if move.priority != new_priority:
+                move.priority = new_priority
 
     def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -503,18 +503,26 @@ class StockLocationOrderpoint(models.Model):
         self._assign_replenishment_moves(
             replenishment_moves.filtered(lambda m: m.state != "assigned")
         )
-        picking_priority_to_update = env["stock.picking"]
+        picking_priority_to_update = self.env["stock.picking"]
         for move in replenishment_moves.sudo():
             new_priority = move.location_orderpoint_id.priority
             if move.priority != new_priority:
                 move.priority = new_priority
                 picking_priority_to_update |= move.picking_id
         for picking in picking_priority_to_update:
-             new_priority = max(picking.move_ids.filtered(lambda m: m.state != "cancel").priority)
-             if picking.priority != new_priority:
-                picking.priority = new_priority
-
-
+            new_priority = max(
+                picking.move_ids.filtered(lambda m: m.state != "cancel").mapped(
+                    "priority"
+                )
+            )
+            if picking.priority != new_priority:
+                # we want to avoid to override the individual move priority by the
+                # picking priority, so we protect the priority field on the
+                # picking's moves
+                with self.env.protecting(
+                    [self.env["stock.move"]._fields["priority"]], picking.move_ids
+                ):
+                    picking.priority = new_priority
 
     def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -503,12 +503,18 @@ class StockLocationOrderpoint(models.Model):
         self._assign_replenishment_moves(
             replenishment_moves.filtered(lambda m: m.state != "assigned")
         )
+        picking_priority_to_update = env["stock.picking"]
         for move in replenishment_moves.sudo():
             new_priority = move.location_orderpoint_id.priority
-            if move.picking_id.priority != new_priority:
-                move.picking_id.priority = new_priority
             if move.priority != new_priority:
                 move.priority = new_priority
+                picking_priority_to_update |= move.picking_id
+        for picking in picking_priority_to_update:
+             new_priority = max(picking.move_ids.filtered(lambda m: m.state != "cancel").priority)
+             if picking.priority != new_priority:
+                picking.priority = new_priority
+
+
 
     def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """

--- a/stock_location_orderpoint/models/stock_move.py
+++ b/stock_location_orderpoint/models/stock_move.py
@@ -110,3 +110,12 @@ class StockMove(models.Model):
         # (state, ...)
         moves._prepare_auto_replenishment_for_incoming_moves()
         return moves
+
+    def _merge_moves_fields(self):
+        # Make sure to link to the highest-priority orderpoint.
+        # This ensures the merged move inherits the correct priority
+        res = super()._merge_moves_fields()
+        res["location_orderpoint_id"] = max(
+            self, key=lambda x: x.location_orderpoint_id.priority
+        ).location_orderpoint_id
+        return res

--- a/stock_location_orderpoint/readme/CONFIGURE.rst
+++ b/stock_location_orderpoint/readme/CONFIGURE.rst
@@ -53,3 +53,8 @@ Location Orderpoint configuration
    for product available quantities when triggering a replenishment (e.g.: Supplier locations - 
    to avoid confirmed receptions taken into account), fill in the 
    'Domain to filter locations' field.
+
+When different orderpoints are defined on the same location, it could result in the creation of several
+replenishment moves for the same product. When this happens, if the moves are merged together, the
+resulting move will be linked to the orderpoint with the highest priority, ensuring that the move 
+inherits the correct priority and is processed accordingly.

--- a/stock_location_orderpoint/readme/CONTRIBUTORS.rst
+++ b/stock_location_orderpoint/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Michael Tietz (MT Software) <mtietz@mt-software.de>
 * Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 * Denis Roussel <denis.roussel@acsone.eu>
+* Nicolas Delbovier <nicolas.delbovier@acsone.eu>

--- a/stock_location_orderpoint/tests/__init__.py
+++ b/stock_location_orderpoint/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_location_orderpoint
+from . import test_location_orderpoint_priority
 from . import test_location_domain

--- a/stock_location_orderpoint/tests/test_location_orderpoint.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint.py
@@ -9,7 +9,6 @@ from psycopg2 import IntegrityError
 from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tools import mute_logger
-from odoo.tools.date_utils import get_timedelta
 
 from odoo.addons.queue_job.job import identity_exact
 from odoo.addons.queue_job.tests.common import trap_jobs
@@ -97,12 +96,12 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
         self.assertFalse(replenish_move)
 
         # create the available quantity -> replenishment
-        tomorrow = now + get_timedelta(1, "day")
+        tomorrow = fields.Datetime.add(now, days=1)
         with self._freeze_time(tomorrow):
             self._set_qty_in_location(self.product, location_src, 12)
 
         self.product.invalidate_recordset()
-        day_after_tomorrow = now + get_timedelta(2, "day")
+        day_after_tomorrow = fields.Datetime.add(now, days=2)
         with self._freeze_time(day_after_tomorrow):
             cron.method_direct_trigger()
 

--- a/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
@@ -147,6 +147,72 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
         self.assertEqual("1", replenish_move.priority)
         self.assertEqual("1", replenish_move_2.priority)
 
+    def test_mixed_replenishment_priority_bis(self):
+        """
+        Create a manual orderpoint with 'normal' priority
+
+        Create moves that will generate replenishment (outgoing + quantity on Reserve).
+
+        Run the manual orderpoint
+
+        Check the move is created
+
+        Create a second orderpoint with 'urgent' priority
+
+        Create moves that will generate replenishment (outgoing + quantity on Reserve).
+
+        Run the second orderpoint for an other product
+
+        Check the move is created
+
+        Each moves must:
+        - be linked to the correct orderpoint
+        - have the correct priority
+
+        The picking must have the highest priority between the 2 moves (i.e. 'urgent')
+
+        """
+        # we drop the unique constraint here because ideally we want to create orderpoints
+        # for the same location with different priority
+        self.env.cr.execute(
+            """
+            ALTER TABLE stock_location_orderpoint
+            DROP CONSTRAINT stock_location_orderpoint_location_route_unique;
+            """
+        )
+        product_1 = self.product
+        product_2 = self.env["product.product"].create(
+            {
+                "name": "Product 2",
+                "type": "product",
+            }
+        )
+        move_qty = 12
+
+        orderpoint, location_src = self._create_orderpoint_complete(
+            "Stock2",
+            trigger="manual",
+        )
+        self._create_outgoing_move(move_qty)
+        self._create_incoming_move(move_qty, location_src)
+        orderpoint.run_replenishment()
+        replenish_move_1 = self._get_replenishment_move(orderpoint, product=product_1)
+
+        orderpoint_2 = orderpoint.copy({"priority": "1"})
+        self.product = product_2
+        self._create_outgoing_move(move_qty, product=product_2)
+        self._create_incoming_move(move_qty, location_src, product=product_2)
+        orderpoint_2.run_replenishment()
+        replenish_move_2 = self._get_replenishment_move(orderpoint_2, product=product_2)
+
+        self.assertTrue(replenish_move_1)
+        self.assertTrue(replenish_move_2)
+
+        self.assertEqual("0", replenish_move_1.priority)
+        self.assertEqual("1", replenish_move_2.priority)
+        self.assertEqual(replenish_move_1.picking_id, replenish_move_2.picking_id)
+        self.assertEqual("1", replenish_move_1.picking_id.priority)
+
     def test_merged_replenishment_move_priority(self):
         """
         Test that merged replenishment moves coming from different orderpoints

--- a/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
@@ -1,0 +1,213 @@
+# Copyright 2023 ACSONE SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo.addons.queue_job.job import identity_exact
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+from .common import TestLocationOrderpointCommon
+
+
+class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
+    def test_mixed_replenishment_priority(self):
+        """
+        Create a manual orderpoint with 'normal' priority
+
+        Create moves that will generate replenishment (ougoing + quantity on Reserve).
+
+        Run the manual orderpoint
+
+        Check the move is created
+
+        Make the orderpoint an automatic orderpoint with 'urgent' priority
+
+        Change the existing outgoing move quantity (with lower need)
+
+        Create an outgoing move with the difference quantity (no move should be created)
+
+        Check that the replenishment move priority has changed to 'urgent'.
+        """
+        job_func = self.env["stock.location.orderpoint"].run_auto_replenishment
+        move_qty = 12
+
+        manual_orderpoint, location_src = self._create_orderpoint_complete(
+            "Stock2",
+            trigger="manual",
+        )
+        out_move = self._create_outgoing_move(move_qty)
+        self._create_incoming_move(move_qty, location_src)
+        manual_orderpoint.run_replenishment()
+        replenish_move_manual = self._get_replenishment_move(manual_orderpoint)
+
+        self.assertTrue(replenish_move_manual)
+        self.assertEqual(12.0, replenish_move_manual.product_uom_qty)
+        self.assertEqual("0", replenish_move_manual.priority)
+
+        # Change the outgoing quantity
+        out_move.product_uom_qty = 6.0
+
+        self.assertEqual(6.0, out_move.product_uom_qty)
+
+        manual_orderpoint.update(
+            {
+                "trigger": "auto",
+                "priority": "1",
+            }
+        )
+
+        with trap_jobs() as trap:
+            out_move_2 = self._create_outgoing_move(2.0)
+            trap.assert_jobs_count(1, only=job_func)
+            trap.assert_enqueued_job(
+                manual_orderpoint.browse([]).run_auto_replenishment,
+                args=(out_move_2.product_id, out_move_2.location_id, "location_id"),
+                kwargs={},
+                properties=dict(
+                    identity_key=identity_exact,
+                ),
+            )
+            trap.perform_enqueued_jobs()
+
+        replenish_move = self._get_replenishment_move(manual_orderpoint)
+        self.assertEqual(replenish_move, replenish_move_manual)
+
+        self.assertEqual(replenish_move.product_uom_qty, 12.0)
+
+        # Check priority has been changed
+        self.assertEqual("1", replenish_move.priority)
+
+    def test_mixed_replenishment_priority_two_products(self):
+        """
+        Create a manual orderpoint with 'normal' priority
+
+        Create moves that will generate replenishment (outgoing + quantity on Reserve).
+
+        Run the manual orderpoint
+
+        Check the move is created
+
+        Update orderpoint priority to 'urgent'
+
+        Change the existing outgoing move quantity (with lower need)
+
+        Create an outgoing move with the difference quantity (no move should be created)
+
+        Check that both replenishment moves priority has changed to 'urgent'.
+        """
+        product_1 = self.product
+        product_2 = self.env["product.product"].create(
+            {
+                "name": "Product 2",
+                "type": "product",
+            }
+        )
+        move_qty = 12
+
+        orderpoint, location_src = self._create_orderpoint_complete(
+            "Stock2",
+            trigger="manual",
+        )
+        out_move = self._create_outgoing_move(move_qty)
+        self._create_incoming_move(move_qty, location_src)
+
+        self.product = product_2
+        self._create_outgoing_move(move_qty, product=product_2)
+        self._create_incoming_move(move_qty, location_src, product=product_2)
+
+        orderpoint.run_replenishment()
+
+        replenish_move_manual_1 = self._get_replenishment_move(
+            orderpoint, product=product_1
+        )
+        replenish_move_manual_2 = self._get_replenishment_move(
+            orderpoint, product=product_2
+        )
+
+        self.assertTrue(replenish_move_manual_1)
+        self.assertTrue(replenish_move_manual_2)
+
+        # Change the outgoing quantity
+        out_move.product_uom_qty = 6.0
+        self.assertEqual(6.0, out_move.product_uom_qty)
+
+        orderpoint.priority = "1"
+
+        self.product = product_1
+        self._create_outgoing_move(2.0)
+
+        orderpoint.run_replenishment()
+
+        replenish_move = self._get_replenishment_move(orderpoint, product=product_1)
+        replenish_move_2 = self._get_replenishment_move(orderpoint, product=product_2)
+
+        self.assertEqual(replenish_move, replenish_move_manual_1)
+        self.assertEqual(replenish_move.product_uom_qty, 12.0)
+
+        # Check priority has been changed (for both moves)
+        self.assertEqual("1", replenish_move.priority)
+        self.assertEqual("1", replenish_move_2.priority)
+
+    def test_merged_replenishment_move_priority(self):
+        """
+        Test that merged replenishment moves coming from different orderpoints
+        inherit the highest priority orderpoint.
+
+        Setup:
+            - Create a manual orderpoint with priotity 0
+            - Create a manual orderpoint with priotity 1 (same location as 1st one)
+            - Create a shortage on orderpoints location
+            - trigger orderpoint 0 for replenishment
+            - Create a shortage on location again
+            - Trigger orderpoint 1 for replenishment
+
+        Expected result:
+            - The resulting merged repl move to account for both shortage set on
+              location should be linked to orderpoint '1' (and have a priority of '1')
+        """
+
+        # ↓ we drop the unique constraint here because ideally we want to create orderpoints
+        # that have exactly the same characteristics except for the replenish_method (in order
+        # to make sure the moves get merged)
+        # However, we only have 1 replenish_method available and we do not want to
+        # add another dependency (e.g. avg_daily_sale)
+        self.env.cr.execute(
+            """
+            ALTER TABLE stock_location_orderpoint
+            DROP CONSTRAINT stock_location_orderpoint_location_route_unique;
+            """
+        )
+
+        (
+            manual_orderpoint_1,
+            orderpoints_src_location,
+        ) = self._create_orderpoint_complete(
+            "Reserve",
+            trigger="manual",
+        )
+        manual_orderpoint_2 = manual_orderpoint_1.copy({"priority": "1"})
+
+        self.assertEqual(
+            manual_orderpoint_1.location_id, manual_orderpoint_2.location_id
+        )
+        self.assertEqual(
+            manual_orderpoint_1.location_src_id, manual_orderpoint_2.location_src_id
+        )
+        self.assertEqual(manual_orderpoint_1.route_id, manual_orderpoint_2.route_id)
+
+        # Make some stock in the orderpoints sources
+        self._create_incoming_move(100, orderpoints_src_location)
+
+        # create a move that introduces a shortage on orderpoints location
+        self._create_outgoing_move(20)
+
+        # trigger creation of first orderpoint repl move
+        manual_orderpoint_1.run_replenishment()
+        repl_move = self._get_replenishment_move(manual_orderpoint_1)
+        self._assert_replenishment_move(repl_move, 20, manual_orderpoint_1)
+
+        # introduce shortage again on orderpoints location
+        self._create_outgoing_move(20)
+
+        # trigger creation of first orderpoint repl move
+        manual_orderpoint_2.run_replenishment()
+        self._assert_replenishment_move(repl_move, 40, manual_orderpoint_2)


### PR DESCRIPTION
When different orderpoints are defined on the same location, it could result in the creation of several
replenishment moves for the same product. When this happens, if the moves are merged together, the
resulting move will be linked to the orderpoint with the highest priority, ensuring that the move 
inherits the correct priority and is processed accordingly.

supersedes #55 by making it a standard feature