### PR TITLE
[16.0][IMP] stock_location_orderpoint: refactor of the stock location orderpoint module

### DIFF
--- a/stock_location_orderpoint/__manifest__.py
+++ b/stock_location_orderpoint/__manifest__.py
@@ -1,12 +1,13 @@
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# Copyright 2026 ACSONE SA/NV (https://acsone.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
     "name": "stock_location_orderpoint",
-    "author": "MT Software, BCIM, Odoo Community Association (OCA)",
+    "author": "MT Software, BCIM, ACSONE SA/NV, Odoo Community Association (OCA)",
     "summary": "Declare orderpoint on a location "
     "allowing to replenish any product with the same criteria.",
-    "version": "16.0.2.0.3",
+    "version": "16.0.3.0.0",
     "data": [
         "security/ir.model.access.csv",
         "security/stock_location_orderpoint_security.xml",
@@ -30,6 +31,6 @@
         "queue_job",
     ],
     "license": "AGPL-3",
-    "maintainers": ["mt-software-de"],
+    "maintainers": ["mt-software-de", "lmignon"],
     "website": "https://github.com/OCA/stock-logistics-orderpoint",
 }

--- a/stock_location_orderpoint/data/queue_job_channel.xml
+++ b/stock_location_orderpoint/data/queue_job_channel.xml
@@ -1,10 +1,24 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
     <record
+        id="channel_stock_location_orderpoint_replenishment"
+        model="queue.job.channel"
+    >
+        <field name="name">stock_location_orderpoint_replenishment</field>
+        <field name="parent_id" ref="queue_job.channel_root" />
+    </record>
+    <record
         id="channel_stock_location_orderpoint_auto_replenishment"
         model="queue.job.channel"
     >
         <field name="name">stock_location_orderpoint_auto_replenishment</field>
-        <field name="parent_id" ref="queue_job.channel_root" />
+        <field name="parent_id" ref="channel_stock_location_orderpoint_replenishment" />
+    </record>
+    <record
+        id="channel_stock_location_orderpoint_procurement_run"
+        model="queue.job.channel"
+    >
+        <field name="name">stock_location_orderpoint_procurement_run</field>
+        <field name="parent_id" ref="channel_stock_location_orderpoint_replenishment" />
     </record>
 </odoo>

--- a/stock_location_orderpoint/data/queue_job_function.xml
+++ b/stock_location_orderpoint/data/queue_job_function.xml
@@ -5,10 +5,22 @@
         model="queue.job.function"
     >
         <field name="model_id" ref="model_stock_location_orderpoint" />
-        <field name="method">run_auto_replenishment</field>
+        <field name="method">run_replenishment</field>
         <field
             name="channel_id"
             ref="channel_stock_location_orderpoint_auto_replenishment"
+        />
+        <field name="retry_pattern" eval="{1: 1, 5: 5, 10: 10, 15: 30}" />
+    </record>
+    <record
+        id="job_function_stock_location_orderpoint_delayed_execute_procurements"
+        model="queue.job.function"
+    >
+        <field name="model_id" ref="model_stock_location_orderpoint" />
+        <field name="method">_fulfill_procurement</field>
+        <field
+            name="channel_id"
+            ref="channel_stock_location_orderpoint_procurement_run"
         />
         <field name="retry_pattern" eval="{1: 1, 5: 5, 10: 10, 15: 30}" />
     </record>

--- a/stock_location_orderpoint/migrations/16.0.3.0.0/post-migrate.py
+++ b/stock_location_orderpoint/migrations/16.0.3.0.0/post-migrate.py
@@ -1,0 +1,10 @@
+# Copyright 2023 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, "stock_location_orderpoint", "data/queue_job_function.xml", mode="init"
+    )

--- a/stock_location_orderpoint/models/__init__.py
+++ b/stock_location_orderpoint/models/__init__.py
@@ -2,3 +2,6 @@ from . import stock_location_orderpoint
 from . import stock_rule
 from . import stock_move
 from . import stock_location
+from . import stock_location_orderpoint_strategy
+from . import stock_location_orderpoint_strategy_fill_up
+from . import stock_location_replenishment_computer

--- a/stock_location_orderpoint/models/stock_location.py
+++ b/stock_location_orderpoint/models/stock_location.py
@@ -75,6 +75,19 @@ class StockLocation(models.Model):
         return expression.AND([domain_move_out_loc, domain])
 
     @api.model
+    def _get_replenishing_moves_domain(self, location_id):
+        """Get the domain to apply on stock.move to get the moves replenishing a location."""
+        (
+            _q,
+            domain_move_in_loc,
+            _ol,
+        ) = self._get_stock_domains(location_id)
+        domain = [
+            ("state", "in", ("confirmed", "assigned", "partially_available")),
+        ]
+        return expression.AND([domain_move_in_loc, domain])
+
+    @api.model
     def _get_replenished_moves_domain(self, location_id):
         """Get the domain to apply on stock.move to get the move having repeished the
         location."""

--- a/stock_location_orderpoint/models/stock_location.py
+++ b/stock_location_orderpoint/models/stock_location.py
@@ -88,18 +88,18 @@ class StockLocation(models.Model):
         ]
         return expression.AND([domain_move_in_loc, domain])
 
-    def _clear_caches(self):
+    def _lop_clear_caches(self):
         self._get_cached_stock_domains.clear_cache(self)
 
     @api.model_create_multi
     def create(self, vals_list):
-        self._clear_caches()
+        self._lop_clear_caches()
         return super().create(vals_list)
 
     def write(self, vals):
-        self._clear_caches()
+        self._lop_clear_caches()
         return super().write(vals)
 
     def unlink(self):
-        self._clear_caches()
+        self._lop_clear_caches()
         return super().unlink()

--- a/stock_location_orderpoint/models/stock_location.py
+++ b/stock_location_orderpoint/models/stock_location.py
@@ -55,47 +55,34 @@ class StockLocation(models.Model):
     def _get_cached_stock_domains(self, location_id):
         return self.env["product.product"]._get_domain_locations_new(location_id)
 
-    def _get_stock_domains(self, location_id):
+    def _get_stock_domains(self):
+        self.ensure_one()
         domain = self.env.context.get("excluded_location_domain", [])
         return self.with_context(
             excluded_location_domain_cache_key=make_hashable(domain)
-        )._get_cached_stock_domains(location_id)
+        )._get_cached_stock_domains(self.id)
 
-    @api.model
-    def _get_consuming_moves_domain(self, location_id):
+    def _get_consuming_moves_domain(self):
         """Get the domain to apply on stock.move to get the consuming moves of a location."""
         (
             _q,
             _il,
             domain_move_out_loc,
-        ) = self._get_stock_domains(location_id)
+        ) = self._get_stock_domains()
         domain = [
             ("state", "in", ("confirmed", "partially_available")),
         ]
         return expression.AND([domain_move_out_loc, domain])
 
     @api.model
-    def _get_replenishing_moves_domain(self, location_id):
-        """Get the domain to apply on stock.move to get the moves replenishing a location."""
-        (
-            _q,
-            domain_move_in_loc,
-            _ol,
-        ) = self._get_stock_domains(location_id)
-        domain = [
-            ("state", "in", ("confirmed", "assigned", "partially_available")),
-        ]
-        return expression.AND([domain_move_in_loc, domain])
-
-    @api.model
-    def _get_replenished_moves_domain(self, location_id):
-        """Get the domain to apply on stock.move to get the move having repeished the
+    def _get_replenished_moves_domain(self):
+        """Get the domain to apply on stock.move to get the move having replenished the
         location."""
         (
             _q,
             domain_move_in_loc,
             _ol,
-        ) = self._get_stock_domains(location_id)
+        ) = self._get_stock_domains()
         domain = [
             ("state", "=", "done"),
         ]

--- a/stock_location_orderpoint/models/stock_location.py
+++ b/stock_location_orderpoint/models/stock_location.py
@@ -1,7 +1,16 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import api, fields, models, tools
+from odoo.osv import expression
 from odoo.tools.safe_eval import safe_eval
+
+
+def make_hashable(val):
+    if isinstance(val, list):
+        return tuple(make_hashable(v) for v in val)
+    if isinstance(val, dict):
+        return tuple(sorted((k, make_hashable(v)) for k, v in val.items()))
+    return val
 
 
 class StockLocation(models.Model):
@@ -40,3 +49,57 @@ class StockLocation(models.Model):
             else:
                 action["context"] = str({"default_location_id": self.id})
         return action
+
+    @api.model
+    @tools.ormcache_context("location_id", keys=("excluded_location_domain_cache_key",))
+    def _get_cached_stock_domains(self, location_id):
+        return self.env["product.product"]._get_domain_locations_new(location_id)
+
+    def _get_stock_domains(self, location_id):
+        domain = self.env.context.get("excluded_location_domain", [])
+        return self.with_context(
+            excluded_location_domain_cache_key=make_hashable(domain)
+        )._get_cached_stock_domains(location_id)
+
+    @api.model
+    def _get_consuming_moves_domain(self, location_id):
+        """Get the domain to apply on stock.move to get the consuming moves of a location."""
+        (
+            _q,
+            _il,
+            domain_move_out_loc,
+        ) = self._get_stock_domains(location_id)
+        domain = [
+            ("state", "in", ("confirmed", "partially_available")),
+        ]
+        return expression.AND([domain_move_out_loc, domain])
+
+    @api.model
+    def _get_replenished_moves_domain(self, location_id):
+        """Get the domain to apply on stock.move to get the move having repeished the
+        location."""
+        (
+            _q,
+            domain_move_in_loc,
+            _ol,
+        ) = self._get_stock_domains(location_id)
+        domain = [
+            ("state", "=", "done"),
+        ]
+        return expression.AND([domain_move_in_loc, domain])
+
+    def _clear_caches(self):
+        self._get_cached_stock_domains.clear_cache(self)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        self._clear_caches()
+        return super().create(vals_list)
+
+    def write(self, vals):
+        self._clear_caches()
+        return super().write(vals)
+
+    def unlink(self):
+        self._clear_caches()
+        return super().unlink()

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -466,33 +466,43 @@ class StockLocationOrderpoint(models.Model):
     def run_replenishment(self, products=False):
         """Run the replenishment for all potential products or only a selection"""
         procurements = self._prepare_procurements(products)
-        if not procurements:
-            return
-        self.env["procurement.group"].with_context(from_orderpoint=True).run(
-            procurements, raise_user_error=False
-        )
-        self._after_replenishment()
+        if procurements:
+            self.env["procurement.group"].with_context(from_orderpoint=True).run(
+                procurements, raise_user_error=False
+            )
+        replenishment_moves = self._get_current_replenishment_moves(products)
+        self._after_replenishment(replenishment_moves)
+        return replenishment_moves
 
-    def _prepare_to_assign_replenishment_move_domain(self):
-        """Returns a domain which selects moves created by a replenishment"""
+    def _get_current_replenishment_moves(self, products=False):
+        """
+        Returns ongoing replenishment moves created or updated by the
+        given orderpoints.
+        """
         domain = [
-            ("state", "in", ["confirmed", "partially_available"]),
+            ("state", "in", ["confirmed", "partially_available", "assigned"]),
             ("procure_method", "=", "make_to_stock"),
             ("location_orderpoint_id", "in", self.ids),
         ]
-        return domain
-
-    def _assign_replenishment_moves(self):
-        """Assigns moves created by the orderpoints"""
-        domain = self._prepare_to_assign_replenishment_move_domain()
-        moves_to_assign = self.env["stock.move"].search(
+        if products:
+            domain = expression.AND([domain, [("product_id", "in", products.ids)]])
+        return self.env["stock.move"].search(
             domain, order="priority desc, date asc, id asc"
         )
+
+    def _assign_replenishment_moves(self, moves_to_assign):
+        """Assigns moves created by the orderpoints"""
         for moves_chunk in split_every(100, moves_to_assign.ids):
             self.env["stock.move"].browse(moves_chunk)._action_assign()
+        return moves_to_assign
 
-    def _after_replenishment(self):
-        self._assign_replenishment_moves()
+    def _after_replenishment(self, replenishment_moves):
+        """
+        Assigns generated replenishment moves.
+        """
+        self._assign_replenishment_moves(
+            replenishment_moves.filtered(lambda m: m.state != "assigned")
+        )
 
     def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -401,21 +401,6 @@ class StockLocationOrderpoint(models.Model):
         orderpoints.write({"last_cron_execution": self.env.cr.now()})
         return res
 
-    @api.model
-    def run_auto_replenishment(self, products, locations, location_field="location_id"):
-        """
-        Run the replenishment for all given products.
-        Selects the right orderpoints by locations and location_field.
-
-        :param products: browse record list of product.product
-        :param locations: browse record list of stock.location
-        :param location_field: should be location_id or location_src_id
-        """
-        if not locations or not products:
-            return
-        orderpoints = self._get_orderpoints("auto", locations, location_field)
-        orderpoints.run_replenishment(products)
-
     def run_replenishment(self, products=None, job_logs=None):
         """
         Public entry point to execute the replenishment rule.

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -503,6 +503,12 @@ class StockLocationOrderpoint(models.Model):
         self._assign_replenishment_moves(
             replenishment_moves.filtered(lambda m: m.state != "assigned")
         )
+        for move in replenishment_moves.sudo():
+            new_priority = move.location_orderpoint_id.priority
+            if move.picking_id.priority != new_priority:
+                move.picking_id.priority = new_priority
+            if move.priority != new_priority:
+                move.priority = new_priority
 
     def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -26,10 +26,9 @@ class StockLocationOrderpoint(models.Model):
     name = fields.Char(
         copy=False,
         required=True,
-        readonly=True,
-        default=lambda self: self.env["ir.sequence"].next_by_code(
-            "stock.location.orderpoint"
-        ),
+        readonly=False,
+        default="/",
+        help="Set to '/' and save if you want a default name to be proposed.",
     )
     company_id = fields.Many2one(
         "res.company",
@@ -815,7 +814,7 @@ class StockLocationOrderpoint(models.Model):
         return moves_to_assign
 
     # -------------------------------------------------------------------------
-    # Cache lifecycle
+    # Cache lifecycle and overrides of create/write/unlink
     # -------------------------------------------------------------------------
 
     def _clear_caches(self):
@@ -828,10 +827,27 @@ class StockLocationOrderpoint(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         self._clear_caches()
-        return super().create(vals_list)
+        val_list_updated = []
+        for vals in vals_list:
+            if "name" not in vals or vals["name"] == "/":
+                val_list_updated.append(
+                    dict(
+                        vals,
+                        name=self.env["ir.sequence"].next_by_code(
+                            "stock.location.orderpoint"
+                        ),
+                    )
+                )
+            else:
+                val_list_updated.append(vals)
+        return super().create(val_list_updated)
 
     def write(self, vals):
         self._clear_caches()
+        if "name" in vals and vals["name"] == "/":
+            vals["name"] = self.env["ir.sequence"].next_by_code(
+                "stock.location.orderpoint"
+            )
         return super().write(vals)
 
     def unlink(self):

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -1,15 +1,19 @@
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# Copyright 2026 ACSONE SA/NV (https://www.acsone.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from collections import defaultdict
 from copy import copy
-from datetime import timedelta
 
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
 from odoo.osv import expression
-from odoo.tools import float_compare, split_every
+from odoo.tools import split_every
 
+from odoo.addons.queue_job.job import identity_exact
 from odoo.addons.stock.models.stock_move import PROCUREMENT_PRIORITIES
+
+from .stock_location_orderpoint_strategy import StockLocationOrderpointStrategy
+from .tools import MovesTouchTracker
 
 
 class StockLocationOrderpoint(models.Model):
@@ -81,15 +85,30 @@ class StockLocationOrderpoint(models.Model):
     location_src_id = fields.Many2one(
         "stock.location", compute="_compute_location_src_id", store=True
     )
+    replenish_limit_to_free_qty = fields.Boolean(
+        string="Limit replenishment to free quantity at source location",
+        help="If enabled, the replenishment quantity will be "
+        "limited to the free quantity at the source location. ",
+        default=True,
+    )
     active = fields.Boolean(default=True)
 
     last_cron_execution = fields.Datetime(
         help="Last time this orderpoint was processed by the cron",
     )
-
     priority = fields.Selection(
         PROCUREMENT_PRIORITIES,
         default="0",
+    )
+    proc_run_async = fields.Boolean(
+        string="Delay procurement execution",
+        help="If enabled, procurements will be run asynchronously in delayed jobs "
+        "when processing this orderpoint. Only applies to 'cron' and 'manual' triggers. "
+        "If disabled, all procurements will be run in the same transaction. ",
+        compute="_compute_proc_run_async",
+        store=True,
+        readonly=False,
+        precompute=True,
     )
 
     _sql_constraints = [
@@ -99,6 +118,10 @@ class StockLocationOrderpoint(models.Model):
             "The combination of Company, Location, Route and Replenish method must be unique",
         )
     ]
+
+    # -------------------------------------------------------------------------
+    # Validation and computed fields
+    # -------------------------------------------------------------------------
 
     @api.constrains("location_id", "route_id")
     def _check_location_id_route_id(self):
@@ -131,400 +154,18 @@ class StockLocationOrderpoint(models.Model):
                 )
             orderpoint.location_src_id = location
 
-    def _prepare_procurement(self, product, qty, date_planned, proc_vals):
-        self.ensure_one()
-        proc_vals = copy(proc_vals)
-        proc_vals.update(
-            {
-                "date_planned": date_planned or fields.Datetime.now(),
-            }
-        )
-        return self.env["procurement.group"].Procurement(
-            product,
-            qty,
-            product.uom_id,
-            self.location_id,
-            self.name,
-            self.name,
-            self.company_id,
-            proc_vals,
-        )
-
-    def _prepare_procurement_values(self):
-        self.ensure_one()
-        return {
-            "route_ids": self.route_id,
-            "date_deadline": False,
-            "warehouse_id": self.location_id.warehouse_id,
-            "group_id": self.group_id,
-            "priority": self.priority or "0",
-            "location_orderpoint_id": self.id,
-        }
-
-    def _get_group_by_domain_config(self):
-        """Returns a list of orederpoints fields for which orderpoints
-        with the same value will generate the same domain for the moves
-        The location_id should be excluded. The location domain will be applied
-        to each group of orderpoints.
-        """
-        return ["last_cron_execution", "trigger", "replenish_method"]
-
-    def _group_by_domain_config(self):
-        """Returns an iterator of orderpoints for which the values of the fields
-        returned by _get_group_by_domain_config will be the same.
-        """
-        groups = defaultdict(list)
+    @api.depends("trigger")
+    def _compute_proc_run_async(self):
         for orderpoint in self:
-            group_key = tuple(
-                getattr(orderpoint, field)
-                for field in orderpoint._get_group_by_domain_config()
-            )
-            groups[group_key].append(orderpoint.id)
-        for group in groups.values():
-            yield self.browse(group)
+            orderpoint.proc_run_async = orderpoint.trigger in ("cron", "manual")
 
-    def _get_consuming_moves_domain_for_group(self):
-        """Returns a domain which selects moves the outgoings that could
-        introduce a shortage at the location for a list of orderpoints
-        with the same characteristics except the location_id
-        """
-        first = self[0]
-        domain = []
-        if first.trigger == "cron":
-            if not first.last_cron_execution:
-                # initialize a date 1 week ago to avoid selecting all moves
-                # when the cron is executed for the first time
-                first.last_cron_execution = self.env.cr.now() - timedelta(days=7)
-            domain.append(("date", ">=", first.last_cron_execution))
-        if first.replenish_method == "fill_up":
-            # with fillup, we know that a replenishment is required when
-            # move are waiting availability
-            domain.append(("state", "in", ["confirmed", "partially_available"]))
-        return domain
+    # -------------------------------------------------------------------------
+    # Orderpoint selection and domains
+    # -------------------------------------------------------------------------
 
-    def _get_consuming_moves_domain(self):
-        """Returns a domain which selects moves the outgoings that could
-        introduce a shortage at the location"""
-        domain = [
-            ("move_orig_ids", "=", False),
-            ("procure_method", "=", "make_to_stock"),
-        ]
-        if self:
-            domain.append(("location_id", "child_of", self.location_id.ids))
-        groups = []
-        for orderpoints in self._group_by_domain_config():
-            group_domain = orderpoints._get_consuming_moves_domain_for_group()
-            if group_domain:
-                groups.append(group_domain)
-        if not groups:
-            return domain
-        return expression.AND([domain, expression.OR(groups)])
-
-    def _get_replenishment_moves_domain_for_group(self):
-        """Returns a domain which selects the incomig moves that could
-        allow a replenishment at the location for a list of orderpoints
-        with the same characteristics except the location_id
-        """
-        first = self[0]
-        domain = []
-        if first.trigger == "cron":
-            if not first.last_cron_execution:
-                # initialize a date 1 week ago to avoid selecting all moves
-                # when the cron is executed for the first time
-                first.last_cron_execution = self.env.cr.now() - timedelta(days=7)
-            domain.append(("date", ">=", first.last_cron_execution))
-        return domain
-
-    def _get_replenishment_moves_domain(self):
-        """Returns a domain which selects moves that could replenish
-        the location"""
-        domain = [
-            ("move_dest_ids", "=", False),
-            ("procure_method", "=", "make_to_stock"),
-            ("state", "=", "done"),
-        ]
-        if self:
-            domain.append(("location_dest_id", "child_of", self.location_src_id.ids))
-        groups = []
-        for orderpoints in self._group_by_domain_config():
-            group_domain = orderpoints._get_replenishment_moves_domain_for_group()
-            if group_domain:
-                groups.append(group_domain)
-        if not groups:
-            return domain
-        return expression.AND([domain, expression.OR(groups)])
-
-    @api.model
-    @tools.ormcache("ids")
-    def _get_consuming_moves_domain_for_ids(self, ids=None):
-        """
-
-        Returns a domain which selects moves the outgoings that could
-        introduce a shortage at the location for a list of orderpoints
-
-        :param frozenset() ids: The orderpoint ids
-        """
-        if ids is not None:
-            ids = list(ids)
-        orderpoints = self.browse(ids) if ids else self.search([])
-        return orderpoints._get_consuming_moves_domain()
-
-    @api.model
-    @tools.ormcache("ids")
-    def _get_replenishment_moves_domain_for_ids(self, ids=None):
-        """
-
-        Returns a domain which selects moves that could replenish
-        the location for a list of orderpoints
-
-        :param frozenset() ids: The orderpoint ids
-        """
-        if ids is not None:
-            ids = list(ids)
-        orderpoints = self.browse(ids) if ids else self.search([])
-        return orderpoints._get_replenishment_moves_domain()
-
-    @api.model
-    def _get_moves_domain(self, ids):
-        """
-        Returns a domain which selects moves replenishing or consuming
-        the locations of orderpoints with given ids
-        """
-        ids = frozenset(ids)
-        return expression.OR(
-            [
-                self._get_replenishment_moves_domain_for_ids(ids),
-                self._get_consuming_moves_domain_for_ids(ids),
-            ]
-        )
-
-    def _find_potential_moves_to_replenish_by_location(self, products=False):
-        """Return a dictionary of products per location that potentially require a replenishment
-        based on the fact there are moves not reserved for those products.
-        This reduces the list of products for which the quantity will be computed"""
-        # We don't use the _get_moves_domain method because. We prefer to make
-        # 2 queries instead of 1 with a big OR statement because the query
-        # planner is not able to use the indexes properly
-        location_ids = []
-        domains = [
-            self._get_replenishment_moves_domain_for_ids(frozenset(self.ids)),
-            self._get_consuming_moves_domain_for_ids(frozenset(self.ids)),
-        ]
-        result = {}
-        for domain in domains:
-            if products:
-                domain = expression.AND([domain, [("product_id", "in", products.ids)]])
-            moves_grouped = self.env["stock.move"].read_group(
-                domain,
-                ["ids:array_agg(id)", "location_id"],
-                "location_id",
-                orderby="id",
-            )
-            for res in moves_grouped:
-                location_ids.append(res["location_id"][0])
-                result.setdefault(res["location_id"][0], []).extend(res["ids"])
-        return {
-            self.env["stock.location"]
-            .browse(location_ids): self.env["stock.move"]
-            .browse(mode_ids)
-            for location_ids, mode_ids in result.items()
-        }
-
-    def _sort_orderpoints(self):
-        return self.sorted()
-
-    @api.model
-    def _compute_quantities_dict(self, locations, products):
-        qties = {}
-        for location in locations:
-            qties_on_location = qties.setdefault(location, {})
-            products = products.with_context(location=location.id)
-            for product_id, qties_dict in products._compute_quantities_dict(
-                None, None, None
-            ).items():
-                product = products.browse(product_id)
-                qties_on_location[product] = qties_dict
-        return qties
-
-    def _get_qty_to_replenish(
-        self, product, qties_on_locations, qty_already_replenished=0
+    def _prepare_orderpoint_domain_location(
+        self, location_ids, location_field="location_id"
     ):
-        """
-        Returns a qty to replenish for a given orderpoint and product
-        """
-        self.ensure_one()
-        product.ensure_one()
-
-        if self.replenish_method == "fill_up":
-            return self._get_qty_to_replenish_fill_up(
-                product, qties_on_locations, qty_already_replenished
-            )
-        return 0
-
-    def _get_qty_to_replenish_fill_up(
-        self, product, qties_on_locations, qty_already_replenished=0
-    ):
-        if not self.location_src_id:
-            return 0
-
-        qties_on_dest = qties_on_locations[self.location_id][product]
-        virtual_available_on_dest = qties_on_dest["virtual_available"]
-        if (
-            float_compare(
-                virtual_available_on_dest,
-                0,
-                precision_rounding=product.uom_id.rounding,
-            )
-            >= 0
-        ):
-            return 0
-
-        virtual_available_on_dest = abs(virtual_available_on_dest)
-        qties_on_src = qties_on_locations[self.location_src_id][product]
-        virtual_available_on_src = (
-            qties_on_src["virtual_available"] - qties_on_src["incoming_qty"]
-        )
-        if (
-            float_compare(
-                virtual_available_on_src,
-                0,
-                precision_rounding=product.uom_id.rounding,
-            )
-            <= 0
-        ):
-            return 0
-
-        qty_to_replenish = virtual_available_on_dest - qty_already_replenished
-        return min(qty_to_replenish, virtual_available_on_src)
-
-    def _get_qties_to_replenish(self, moves_by_location):
-        products = set()
-        for moves in moves_by_location.values():
-            products.update(moves.product_id.ids)
-        qties_replenished = defaultdict(lambda: defaultdict(lambda: 0))
-        qties_to_replenish = defaultdict(list)
-        for orderpoint in self:
-            qties_on_locations = self._compute_quantities_dict(
-                (self.location_id | self.location_src_id),
-                self.env["product.product"]
-                .browse(products)
-                .with_context(
-                    excluded_location_domain=orderpoint.stock_excluded_location_domain
-                ),
-            )
-            if orderpoint.location_id not in moves_by_location:
-                continue
-
-            for product in moves_by_location[orderpoint.location_id].product_id:
-                qties_replenished_for_location = qties_replenished[
-                    orderpoint.location_id
-                ]
-                qty_to_replenish = orderpoint._get_qty_to_replenish(
-                    product,
-                    qties_on_locations,
-                    qties_replenished_for_location[product],
-                )
-                if (
-                    float_compare(
-                        qty_to_replenish,
-                        0,
-                        precision_rounding=product.uom_id.rounding,
-                    )
-                    > 0
-                ):
-                    qties_to_replenish[orderpoint].append((product, qty_to_replenish))
-                    qties_replenished_for_location[product] += qty_to_replenish
-        return qties_to_replenish
-
-    def __prepare_procurements(self, moves_by_location):
-        qties_to_replenish_by_orderpoint = self._get_qties_to_replenish(
-            moves_by_location
-        )
-        procurements = []
-        for (
-            orderpoint,
-            qties_to_replenish,
-        ) in qties_to_replenish_by_orderpoint.items():
-            proc_vals = orderpoint._prepare_procurement_values()
-            for product, qty in qties_to_replenish:
-                date_planned = moves_by_location[
-                    orderpoint.location_id
-                ]._get_location_orderpoint_replenishment_date(product)
-                procurements.append(
-                    orderpoint._prepare_procurement(
-                        product, qty, date_planned, proc_vals
-                    )
-                )
-        return procurements
-
-    def _prepare_procurements(self, products=False):
-        moves_by_location = self._find_potential_moves_to_replenish_by_location(
-            products
-        )
-        return self._sort_orderpoints().__prepare_procurements(moves_by_location)
-
-    def run_replenishment(self, products=False):
-        """Run the replenishment for all potential products or only a selection"""
-        procurements = self._prepare_procurements(products)
-        if procurements:
-            self.env["procurement.group"].with_context(from_orderpoint=True).run(
-                procurements, raise_user_error=False
-            )
-        replenishment_moves = self._get_current_replenishment_moves(products)
-        self._after_replenishment(replenishment_moves)
-        return replenishment_moves
-
-    def _get_current_replenishment_moves(self, products=False):
-        """
-        Returns ongoing replenishment moves created or updated by the
-        given orderpoints.
-        """
-        domain = [
-            ("state", "in", ["confirmed", "partially_available", "assigned"]),
-            ("procure_method", "=", "make_to_stock"),
-            ("location_orderpoint_id", "in", self.ids),
-        ]
-        if products:
-            domain = expression.AND([domain, [("product_id", "in", products.ids)]])
-        return self.env["stock.move"].search(
-            domain, order="priority desc, date asc, id asc"
-        )
-
-    def _assign_replenishment_moves(self, moves_to_assign):
-        """Assigns moves created by the orderpoints"""
-        for moves_chunk in split_every(100, moves_to_assign.ids):
-            self.env["stock.move"].browse(moves_chunk)._action_assign()
-        return moves_to_assign
-
-    def _after_replenishment(self, replenishment_moves):
-        """
-        Assigns generated replenishment moves.
-        """
-        self._assign_replenishment_moves(
-            replenishment_moves.filtered(lambda m: m.state != "assigned")
-        )
-        picking_priority_to_update = self.env["stock.picking"]
-        for move in replenishment_moves.sudo():
-            new_priority = move.location_orderpoint_id.priority
-            if move.priority != new_priority:
-                move.priority = new_priority
-                picking_priority_to_update |= move.picking_id
-        for picking in picking_priority_to_update:
-            new_priority = max(
-                picking.move_ids.filtered(lambda m: m.state != "cancel").mapped(
-                    "priority"
-                )
-            )
-            if picking.priority != new_priority:
-                # we want to avoid to override the individual move priority by the
-                # picking priority, so we protect the priority field on the
-                # picking's moves
-                with self.env.protecting(
-                    [self.env["stock.move"]._fields["priority"]], picking.move_ids
-                ):
-                    picking.priority = new_priority
-
-    def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """
         Returns the domain part of the location selection of _get_orderpoints
         :param list int location_ids: list of stock.location ids
@@ -535,11 +176,11 @@ class StockLocationOrderpoint(models.Model):
         if not isinstance(ids, list):
             ids = ids.ids
 
-        location_field = not location_field and "location_id" or location_field
+        location_field = location_field or "location_id"
         return [(location_field, "parent_of", ids)]
 
     def _prepare_orderpoint_domain(
-        self, trigger, locations=False, location_field=False
+        self, trigger, locations=None, location_field="location_id"
     ):
         """Returns the domain for _get_orderpoints"""
         domain = [("trigger", "=", trigger)]
@@ -569,7 +210,7 @@ class StockLocationOrderpoint(models.Model):
         return result
 
     @api.model
-    def _get_orderpoints(self, trigger, locations=False, location_field="location_id"):
+    def _get_orderpoints(self, trigger, locations=None, location_field="location_id"):
         """Returns orderpoints selected by trigger, locations and location_field"""
         ids_by_parent_paths = self._get_ids_by_parent_path(trigger, location_field)
         ids = set()
@@ -581,42 +222,184 @@ class StockLocationOrderpoint(models.Model):
         else:
             # ids_by_parent_paths.values() is a list of ids. We need to flatten it
             ids = set().union(*ids_by_parent_paths.values())
-        return self.browse(list(ids))
-
-    def _is_location_parent_of(self, location, location_field):
-        """
-        Checks if one location of the given orderpoints
-        is a parent of the given location
-
-        :param location: browse record of stock.location
-        :param location_field: should be location_id or location_src_id
-            orderpoints location field to check against
-        """
-        for parent_location in getattr(self, location_field):
-            if location.parent_path.startswith(parent_location.parent_path):
-                return True
+        return self.browse(list(ids)).sorted()
 
     @api.model
-    def _filter_moves_triggering_orderpoints(self, moves, trigger="auto"):
-        """Filters moves that trigger orderpoints"""
+    def _get_orderpoints_from_moves(self, moves, trigger="auto"):
+        """Return orderpoints impacted by the given move set."""
+        orderpoints = self._get_orderpoints(
+            trigger, locations=moves.location_id, location_field="location_id"
+        )
+        return orderpoints | self._get_orderpoints(
+            trigger, locations=moves.location_dest_id, location_field="location_src_id"
+        )
+
+    @api.model
+    @tools.ormcache("orderpoint_id")
+    def _get_consuming_moves_domain(self, orderpoint_id):
+        (
+            _q,
+            _il,
+            domain_move_out_loc,
+        ) = self._get_dest_domains(orderpoint_id)
+        domain = [
+            ("state", "in", ("confirmed", "partially_available")),
+        ]
+        return expression.AND([domain_move_out_loc, domain])
+
+    @api.model
+    @tools.ormcache("orderpoint_id")
+    def _get_supplying_moves_domain(self, orderpoint_id):
+        (
+            _q,
+            domain_move_in_loc,
+            _ol,
+        ) = self._get_src_domains(orderpoint_id)
+        domain = [
+            ("state", "=", "done"),
+        ]
+        return expression.AND([domain_move_in_loc, domain])
+
+    @api.model
+    def _collect_products_by_orderpoint(self, moves, orderpoints, get_moves_domain):
+        """Group impacted products by orderpoint using a domain provider."""
+        products_by_orderpoint = defaultdict(self.env["product.product"].browse)
+        for orderpoint in orderpoints:
+            moves_for_orderpoint = moves.filtered_domain(
+                get_moves_domain(orderpoint.id)
+            )
+            if not moves_for_orderpoint:
+                continue
+            products_by_orderpoint[orderpoint] |= moves_for_orderpoint.product_id
+        return products_by_orderpoint
+
+    @api.model
+    def _get_from_move_demand(self, moves, trigger="auto"):
+        """
+        Return a dict of products by orderpoint to replenish the demand
+        generated by the given moves. (The given moves are consuming the
+        orderpoint location).
+        :param moves: stock.move recordset
+        :param trigger: the trigger to consider to select the orderpoints to replenish
+        :return: dict {orderpoint: products}
+        """
         # move from location consume order point location -> DO I've to replenish?
         orderpoints = self._get_orderpoints(
             trigger, locations=moves.location_id, location_field="location_id"
         )
-        # move to src location replenish order point source location -> DO I've to replenish?
-        orderpoints = orderpoints | self._get_orderpoints(
-            trigger, locations=moves.location_dest_id, location_field="location_src_id"
+        return self._collect_products_by_orderpoint(
+            moves, orderpoints, self._get_consuming_moves_domain
         )
-        if not orderpoints:
-            return self.env["stock.move"]
-        moves = moves.filtered_domain(self._get_moves_domain(orderpoints.ids))
-        return moves
 
     @api.model
-    def run_auto_replenishment(self, products, locations, location_field=False):
+    def _get_from_move_supply(self, moves, trigger="auto"):
         """
-        Run the replenishment for all given products
-        Selects the right orderpoints by locations and location_field
+        Return a dict of products by orderpoint to replenish the demand
+        generated by the given moves. (The given moves are supplying the
+        orderpoint source location).
+        :param moves: stock.move recordset
+        :param trigger: the trigger to consider to select the orderpoints to replenish
+        :return: dict {orderpoint: products}
+        """
+        # move to src location replenish order point source location -> DO I've to replenish?
+        orderpoints = self._get_orderpoints(
+            trigger, locations=moves.location_dest_id, location_field="location_src_id"
+        )
+        return self._collect_products_by_orderpoint(
+            moves, orderpoints, self._get_supplying_moves_domain
+        )
+
+    @api.model
+    @tools.ormcache("orderpoint_id")
+    def _get_src_domains(self, orderpoint_id):
+        """Get the quant, move in and move out domains
+        for the orderpoint location source and its children locations
+        """
+        orderpoint = self.browse(orderpoint_id)
+        return orderpoint._product_model._get_domain_locations_new(
+            [orderpoint.location_src_id.id]
+        )
+
+    @api.model
+    @tools.ormcache("orderpoint_id")
+    def _get_dest_domains(self, orderpoint_id):
+        """Get the quant, move in and move out domains
+        for the orderpoint location destination and its children locations
+        """
+        orderpoint = self.browse(orderpoint_id)
+        return orderpoint._product_model._get_domain_locations_new(
+            [orderpoint.location_id.id]
+        )
+
+    # -------------------------------------------------------------------------
+    # Context-aware model accessors
+    # -------------------------------------------------------------------------
+
+    @property
+    def _product_model(self):
+        """Returns the product model scoped with the orderpoint's excluded
+        location domain."""
+        self.ensure_one()
+        return self.env["product.product"]
+
+    @property
+    def _strategy_model(self) -> StockLocationOrderpointStrategy:
+        self.ensure_one()
+        if self.replenish_method == "fill_up":
+            return self.env["stock.location.orderpoint.strategy.fill_up"]
+        raise ValidationError(_("No strategy class available"))
+
+    # -------------------------------------------------------------------------
+    # Replenishment computer
+    # -------------------------------------------------------------------------
+
+    def _get_replenishment_computer(self):
+        """
+        Instantiate the replenishment computer in memory for this orderpoint.
+
+        The computer is an orderpoint-agnostic TransientModel (new() — no DB
+        persistence) that encapsulates the full demand→procurement_qty pipeline.
+        It can equally be instantiated independently of any orderpoint for
+        reporting or external integrations.
+
+        The strategy is injected as an instance rather than passing replenish_method,
+        so that adding a new strategy never requires modifying the computer.
+
+        :return: stock.location.replenishment.computer in-memory record
+        """
+        self.ensure_one()
+        computer = self.env["stock.location.replenishment.computer"].new(
+            self._prepare_replenishment_computer_values()
+        )
+        computer._strategy = self._strategy_model
+        return computer
+
+    def _prepare_replenishment_computer_values(self):
+        """Prepare the values to instantiate the replenishment computer."""
+        self.ensure_one()
+        return {
+            "location_id": self.location_id.id,
+            "location_src_id": self.location_src_id.id,
+            "replenish_limit_to_free_qty": self.replenish_limit_to_free_qty,
+            "excluded_location_domain": self.stock_excluded_location_domain,
+        }
+
+    # -------------------------------------------------------------------------
+    # Public triggers and orchestration
+    # -------------------------------------------------------------------------
+
+    @api.model
+    def run_cron_replenishment(self, location_ids=None):
+        orderpoints = self._get_orderpoints(trigger="cron", locations=location_ids)
+        res = orderpoints.run_replenishment()
+        orderpoints.write({"last_cron_execution": self.env.cr.now()})
+        return res
+
+    @api.model
+    def run_auto_replenishment(self, products, locations, location_field="location_id"):
+        """
+        Run the replenishment for all given products.
+        Selects the right orderpoints by locations and location_field.
 
         :param products: browse record list of product.product
         :param locations: browse record list of stock.location
@@ -624,22 +407,382 @@ class StockLocationOrderpoint(models.Model):
         """
         if not locations or not products:
             return
-        self = self._get_orderpoints("auto", locations, location_field)
-        self.run_replenishment(products)
+        orderpoints = self._get_orderpoints("auto", locations, location_field)
+        orderpoints.run_replenishment(products)
+
+    def run_replenishment(self, products=None, job_logs=None):
+        """
+        Public entry point to execute the replenishment rule.
+
+        :param products: optional recordset of product.product
+            If provided, limits the computation scope.
+        :param job_logs: optional list to collect trace messages. When provided,
+            messages are appended for each step of the pipeline. Used by delayed
+            jobs to build their result string.
+        """
+        result = self.env["stock.move"]
+        processed = set()
+        for orderpoint in self.sorted():
+            result |= orderpoint._run_replenishment(
+                products=products, processed=processed, job_logs=job_logs
+            )
+            processed.update(
+                [orderpoint._processed_key(m.product_id.id) for m in result]
+            )
+        return result
+
+    def _processed_key(self, product_id):
+        """Return the deduplication key for one product in this orderpoint context."""
+        self.ensure_one()
+        return (self.priority, self.location_id.id, product_id)
+
+    def _run_replenishment(self, products=None, processed=None, job_logs=None):
+        """
+        Internal pipeline:
+        1. determine candidate products
+        2. via the replenishment computer: compute demand (async) or
+           demand + procurement qty (sync) in a single call
+        3. either enqueue one job per product (async) or execute immediately (sync)
+
+        Two delay mechanisms coexist in this module:
+
+        - AUTO trigger: delay happens *before* this pipeline in stock.move,
+          one job per (orderpoint, product). _must_delay_fulfill_procurement()
+          always returns False for AUTO orderpoints so execution is always
+          synchronous here.
+
+        - CRON / MANUAL triggers: when proc_run_async is True, demand is
+          computed first (demand_only=True), then one job per product is
+          enqueued. Each job re-runs the full pipeline autonomously
+          (demand_only=False) so that availability and procurement creation
+          are always atomic within a single transaction. The number of jobs
+          is bounded by the number of products with actual demand.
+        """
+        result = self.env["stock.move"]
+        processed = processed or set()
+        self.ensure_one()
+        is_delayed = self._must_delay_fulfill_procurement()
+
+        products = self._get_candidate_products(products)
+
+        # Filter out products already handled by a higher-priority orderpoint
+        # sharing the same location. Only meaningful in the async path.
+        if products is not None and processed and is_delayed:
+            products = products.filtered(
+                lambda p: self._processed_key(p.id) not in processed
+            )
+
+        if not products and products is not None:
+            if job_logs is not None:
+                job_logs.append(
+                    _(
+                        "No products to replenish for orderpoint %(orderpoint)s",
+                        orderpoint=self.display_name,
+                    )
+                )
+            return result
+
+        # Single call to the computer:
+        #   demand_only=True  → returns {product_id: demand_qty}  (async path)
+        #   demand_only=False → returns {product_id: qty_to_procure} (sync path)
+        computer = self._get_replenishment_computer()
+        procurement_data = computer.compute(
+            products=products,
+            demand_only=is_delayed,
+            job_logs=job_logs,
+        )
+
+        # Secondary filter on demand_data for the async path when products=None
+        # lets the strategy return a broader set than what was pre-filtered above.
+        if procurement_data and processed and is_delayed:
+            procurement_data = {
+                pid: qty
+                for pid, qty in procurement_data.items()
+                if self._processed_key(pid) not in processed
+            }
+
+        if not procurement_data:
+            if job_logs is not None:
+                job_logs.append(
+                    _(
+                        "No demand to replenish for orderpoint %(orderpoint)s",
+                        orderpoint=self.display_name,
+                    )
+                )
+            return result
+
+        if is_delayed:
+            for product_id, demand_qty in procurement_data.items():
+                self._enqueue_fulfill_procurement(product_id, demand_qty).delay()
+            return result
+
+        if job_logs is not None:
+            job_logs.append(
+                _(
+                    "Running replenishment for orderpoint %(orderpoint)s "
+                    "for %(product_count)s products.",
+                    orderpoint=self.display_name,
+                    product_count=len(procurement_data),
+                )
+            )
+
+        procurements = self._build_procurements(procurement_data)
+        if not procurements:
+            return result
+
+        result = self._execute_run_procurements(procurements)
+        return self._after_replenishment(result)
+
+    # -------------------------------------------------------------------------
+    # Replenishment execution pipeline (orderpoint-bound)
+    # -------------------------------------------------------------------------
+
+    def _get_candidate_products(self, products=None):
+        """
+        Resolve the product scope.
+
+        Priority:
+        1. explicit products
+        2. strategy override
+        3. default (rule-based — to be implemented if needed)
+
+        :return: product.product recordset or None
+        """
+        self.ensure_one()
+        return self._strategy_model._get_candidate_products(
+            self.location_id, products=products
+        )
+
+    def _build_procurements(self, procurement_data):
+        """Build procurement payload from computed quantities by product id."""
+        self.ensure_one()
+        procurement_vals = self._prepare_procurement_vals()
+        return [
+            self._prepare_procurement(
+                self.env["product.product"].browse(product_id),
+                procurement_qty,
+                date_planned=False,
+                proc_vals=procurement_vals,
+            )
+            for product_id, procurement_qty in procurement_data.items()
+        ]
+
+    def _prepare_procurement_vals(self):
+        """Prepare common values for procurement creation."""
+        self.ensure_one()
+        return {
+            "route_ids": self.route_id,
+            "date_deadline": False,
+            "warehouse_id": self.location_id.warehouse_id,
+            "group_id": self.group_id,
+            "priority": self.priority or "0",
+            "location_orderpoint_id": self.id,
+        }
+
+    def _prepare_procurement(self, product, qty, date_planned, proc_vals):
+        self.ensure_one()
+        proc_vals = copy(proc_vals)
+        proc_vals.update(
+            {
+                "date_planned": date_planned or fields.Datetime.now(),
+            }
+        )
+        return self.env["procurement.group"].Procurement(
+            product,
+            qty,
+            product.uom_id,
+            self.location_id,
+            self.name,
+            self.name,
+            self.company_id,
+            proc_vals,
+        )
+
+    def _execute_run_procurements(self, procurement_values):
+        """
+        Execute the procurements synchronously and return the created moves.
+
+        Shared by all execution paths:
+        - AUTO orderpoints (always synchronous — already inside a queue.job)
+        - CRON / MANUAL when proc_run_async is False
+        - The delayed job _fulfill_procurement() for async cron/manual runs
+
+        :param procurement_values: list of namedtuple Procurement objects
+        :return: recordset of created stock.move
+        """
+        with MovesTouchTracker() as tracker:
+            self.env["procurement.group"].with_context(from_orderpoint=True).run(
+                procurement_values, raise_user_error=False
+            )
+            return self.env["stock.move"].browse(tracker.get_ids()).exists()
+
+    # -------------------------------------------------------------------------
+    # Async delegation — cron / manual only
+    # -------------------------------------------------------------------------
+
+    def _must_delay_fulfill_procurement(self):
+        """
+        Returns True when per-product fulfillment should be deferred to
+        queue.jobs rather than run synchronously in the current transaction.
+
+        Always False for AUTO orderpoints: they already run inside a queue.job
+        enqueued by stock.move (_enqueue_run_replenishment). A second delay
+        would create a superfluous job chain with no benefit.
+
+        For CRON / MANUAL, follows proc_run_async unless force_sync is set
+        in the context (used by _fulfill_procurement to re-enter the pipeline
+        synchronously from within a worker).
+        """
+        self.ensure_one()
+        if self.trigger == "auto":
+            return False
+        if "force_sync" in self.env.context:
+            return not self.env.context["force_sync"]
+        if "queue_job__no_delay" in self.env.context:
+            return not self.env.context["queue_job__no_delay"]
+        return self.proc_run_async
+
+    def _enqueue_fulfill_procurement(self, product_id, demand_qty, **job_options):
+        """
+        Enqueue a delayed job to fulfill the procurement for one product.
+
+        Used exclusively by cron and manual triggers when proc_run_async is True.
+        The actual work is performed by _fulfill_procurement().
+
+        Note: demand_qty is passed for the job description only. The job
+        recomputes everything autonomously to stay independent of the calling
+        transaction's state.
+
+        :param product_id: ID of the product to fulfill
+        :param demand_qty: indicative demanded qty — used for job description only
+        :param job_options: extra options forwarded to the job (priority, …)
+        :return: a Job instance (not yet delayed — caller must call .delay())
+        """
+        job_options = job_options.copy()
+        job_options.setdefault(
+            "description",
+            _(
+                "Try to fulfill procurement for product %(product_name)s in location "
+                "%(location_name)s for a demand of %(demand_qty)s with priority %(priority)s",
+                product_name=self.env["product.product"]
+                .browse(product_id)
+                .display_name,
+                location_name=self.location_id.display_name,
+                demand_qty=demand_qty,
+                priority=self.priority or "0",
+            ),
+        )
+        job_options.setdefault("identity_key", identity_exact)
+        delayable = self.env[self._name].delayable(**job_options)
+        return delayable._fulfill_procurement(
+            self.priority, self.location_id.id, product_id
+        )
 
     @api.model
-    def run_cron_replenishment(self, location_ids=False):
-        self = self._get_orderpoints("cron", location_ids)
-        self.run_replenishment()
-        # use the current transaction date to ensure that orderpoints run
-        # in the same transaction have the same last_cron_execution and are
-        # always grouped together
-        self.write({"last_cron_execution": self.env.cr.now()})
+    def _fulfill_procurement(self, priority, location_id, product_id):
+        """
+        Fulfill the procurement for a single product at a given location and priority.
+
+        Looks up all non-AUTO orderpoints matching (location, priority) and runs
+        the full replenishment pipeline synchronously for the given product.
+        The pipeline re-runs demand computation from scratch inside this transaction,
+        guaranteeing that demand, availability check, and procurement execution are
+        all atomic and independent of any prior state.
+
+        This is the queue.job entry point for async cron/manual runs, but its
+        contract is independent of that context.
+
+        :param priority: procurement priority string to match orderpoints with
+        :param location_id: stock.location id to match orderpoints with
+        :param product_id: product.product id to fulfill
+        :return: a human-readable summary string (stored as the job result)
+        """
+        job_logs = []
+        orderpoints = self.search(
+            [
+                ("priority", "=", priority),
+                ("location_id", "=", location_id),
+                ("trigger", "!=", "auto"),
+            ]
+        )
+        if not orderpoints:
+            job_logs.append(
+                _(
+                    "No orderpoints found for location %(location_name)s "
+                    "with priority %(priority)s",
+                    location_name=self.env["stock.location"]
+                    .browse(location_id)
+                    .display_name,
+                    priority=priority or "0",
+                )
+            )
+            return "\n".join(job_logs)
+
+        product = self.env["product.product"].browse(product_id)
+        result = orderpoints.with_context(force_sync=True).run_replenishment(
+            products=product,
+            job_logs=job_logs,
+        )
+        job_logs.append(
+            _(
+                "Fulfilled procurement for product %(product_name)s "
+                "in location %(location_name)s: %(move_count)s replenishment moves created.",
+                product_name=product.display_name,
+                location_name=orderpoints[0].location_id.display_name,
+                move_count=len(result),
+            )
+        )
+        return "\n".join(job_logs)
+
+    # -------------------------------------------------------------------------
+    # Post-processing of replenishment moves
+    # -------------------------------------------------------------------------
+
+    def _after_replenishment(self, replenishment_moves):
+        """Assigns generated replenishment moves and updates picking priorities."""
+        self._assign_replenishment_moves(
+            replenishment_moves.filtered(lambda m: m.state != "assigned")
+        )
+        picking_priority_to_update = self.env["stock.picking"]
+        for move in replenishment_moves.sudo():
+            new_priority = move.location_orderpoint_id.priority
+            if move.priority != new_priority:
+                move.priority = new_priority
+                picking_priority_to_update |= move.picking_id
+        for picking in picking_priority_to_update:
+            new_priority = max(
+                picking.move_ids.filtered(lambda m: m.state != "cancel").mapped(
+                    "priority"
+                )
+            )
+            if picking.priority != new_priority:
+                # Protect individual move priority from being overridden by
+                # the picking's priority recalculation.
+                with self.env.protecting(
+                    [self.env["stock.move"]._fields["priority"]], picking.move_ids
+                ):
+                    picking.priority = new_priority
+
+        return self._strategy_model._after_run_replenishment(
+            self.location_id, replenishment_moves
+        )
+
+    def _assign_replenishment_moves(self, moves_to_assign):
+        """Assigns moves created by the orderpoints."""
+        for moves_chunk in split_every(100, moves_to_assign.ids):
+            self.env["stock.move"].browse(moves_chunk)._action_assign()
+        return moves_to_assign
+
+    # -------------------------------------------------------------------------
+    # Cache lifecycle
+    # -------------------------------------------------------------------------
 
     def _clear_caches(self):
         self._get_ids_by_parent_path.clear_cache(self)
-        self._get_consuming_moves_domain_for_ids.clear_cache(self)
-        self._get_replenishment_moves_domain_for_ids.clear_cache(self)
+        self._get_consuming_moves_domain.clear_cache(self)
+        self._get_supplying_moves_domain.clear_cache(self)
+        self._get_src_domains.clear_cache(self)
+        self._get_dest_domains.clear_cache(self)
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -647,13 +790,7 @@ class StockLocationOrderpoint(models.Model):
         return super().create(vals_list)
 
     def write(self, vals):
-        # if we only update values that change the group_by_domain
-        moves_domain_caches_update_fields = self._get_group_by_domain_config()
-        if any(field in vals for field in moves_domain_caches_update_fields):
-            self._get_consuming_moves_domain_for_ids.clear_cache(self)
-            self._get_replenishment_moves_domain_for_ids.clear_cache(self)
-        else:
-            self._clear_caches()
+        self._clear_caches()
         return super().write(vals)
 
     def unlink(self):

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -10,7 +10,6 @@ from odoo.osv import expression
 from odoo.tools import split_every
 
 from odoo.addons.queue_job.job import identity_exact
-from odoo.addons.stock.models.stock_move import PROCUREMENT_PRIORITIES
 
 from .stock_location_orderpoint_strategy import StockLocationOrderpointStrategy
 from .tools import MovesTouchTracker
@@ -104,7 +103,7 @@ class StockLocationOrderpoint(models.Model):
         help="Last time this orderpoint was processed by the cron",
     )
     priority = fields.Selection(
-        PROCUREMENT_PRIORITIES,
+        selection="_selection_move_priorities",
         default="0",
     )
     proc_run_async = fields.Boolean(
@@ -125,6 +124,9 @@ class StockLocationOrderpoint(models.Model):
             "The combination of Company, Location, Route and Replenish method must be unique",
         )
     ]
+
+    def _selection_move_priorities(self):
+        return self.env["stock.move"]._fields["priority"].selection
 
     # -------------------------------------------------------------------------
     # Simple properties

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -144,6 +144,22 @@ class StockLocationOrderpoint(models.Model):
         self.ensure_one()
         return fields.Datetime.add(fields.Datetime.now(), days=self.replenish_horizon)
 
+    @property
+    def location(self):
+        """Return the location_id with the excluded_location_domain applied in context."""
+        self.ensure_one()
+        return self.location_id.with_context(
+            excluded_location_domain=self.stock_excluded_location_domain
+        )
+
+    @property
+    def location_src(self):
+        """Return the location_src_id with the excluded_location_domain applied in context."""
+        self.ensure_one()
+        return self.location_src_id.with_context(
+            excluded_location_domain=self.stock_excluded_location_domain
+        )
+
     # -------------------------------------------------------------------------
     # Validation and computed fields
     # -------------------------------------------------------------------------
@@ -263,32 +279,16 @@ class StockLocationOrderpoint(models.Model):
             trigger, locations=moves.location_dest_id, location_field="location_src_id"
         )
 
-    @api.model
-    def _get_consuming_moves_domain(self, orderpoint_id):
-        (
-            _q,
-            _il,
-            domain_move_out_loc,
-        ) = self._get_dest_domains(orderpoint_id)
-        domain = [
-            ("state", "in", ("confirmed", "partially_available")),
-        ]
-        return expression.AND([domain_move_out_loc, domain])
+    def _get_consuming_moves_domain(self):
+        return self.location._get_consuming_moves_domain()
+
+    def _get_supplying_moves_domain(self):
+        return self.location_src._get_replenished_moves_domain()
 
     @api.model
-    def _get_supplying_moves_domain(self, orderpoint_id):
-        (
-            _q,
-            domain_move_in_loc,
-            _ol,
-        ) = self._get_src_domains(orderpoint_id)
-        domain = [
-            ("state", "=", "done"),
-        ]
-        return expression.AND([domain_move_in_loc, domain])
-
-    @api.model
-    def _collect_products_by_orderpoint(self, moves, orderpoints, get_moves_domain):
+    def _collect_products_by_orderpoint(
+        self, moves, orderpoints, get_moves_domain_method: str
+    ):
         """Group impacted products by orderpoint using a domain provider."""
         products_by_orderpoint = defaultdict(self.env["product.product"].browse)
         for orderpoint in orderpoints:
@@ -299,7 +299,7 @@ class StockLocationOrderpoint(models.Model):
                 )
                 moves = moves.filtered(lambda m: m.product_id in authorized_product)
             moves_for_orderpoint = moves.filtered_domain(
-                get_moves_domain(orderpoint.id)
+                getattr(orderpoint, get_moves_domain_method)()
             )
             if not moves_for_orderpoint:
                 continue
@@ -321,7 +321,7 @@ class StockLocationOrderpoint(models.Model):
             trigger, locations=moves.location_id, location_field="location_id"
         )
         return self._collect_products_by_orderpoint(
-            moves, orderpoints, self._get_consuming_moves_domain
+            moves, orderpoints, "_get_consuming_moves_domain"
         )
 
     @api.model
@@ -339,41 +339,12 @@ class StockLocationOrderpoint(models.Model):
             trigger, locations=moves.location_dest_id, location_field="location_src_id"
         )
         return self._collect_products_by_orderpoint(
-            moves, orderpoints, self._get_supplying_moves_domain
-        )
-
-    @api.model
-    @tools.ormcache("orderpoint_id")
-    def _get_src_domains(self, orderpoint_id):
-        """Get the quant, move in and move out domains
-        for the orderpoint location source and its children locations
-        """
-        orderpoint = self.browse(orderpoint_id)
-        return orderpoint._product_model._get_domain_locations_new(
-            [orderpoint.location_src_id.id]
-        )
-
-    @api.model
-    @tools.ormcache("orderpoint_id")
-    def _get_dest_domains(self, orderpoint_id):
-        """Get the quant, move in and move out domains
-        for the orderpoint location destination and its children locations
-        """
-        orderpoint = self.browse(orderpoint_id)
-        return orderpoint._product_model._get_domain_locations_new(
-            [orderpoint.location_id.id]
+            moves, orderpoints, "_get_supplying_moves_domain"
         )
 
     # -------------------------------------------------------------------------
     # Context-aware model accessors
     # -------------------------------------------------------------------------
-
-    @property
-    def _product_model(self):
-        """Returns the product model scoped with the orderpoint's excluded
-        location domain."""
-        self.ensure_one()
-        return self.env["product.product"]
 
     @property
     def _strategy_model(self) -> StockLocationOrderpointStrategy:
@@ -585,7 +556,7 @@ class StockLocationOrderpoint(models.Model):
         """
         self.ensure_one()
         return self._strategy_model._get_candidate_products(
-            self.location_id,
+            self.location,
             self._horizon_datetime,
             self._get_product_domain(),
             products=products,
@@ -802,7 +773,7 @@ class StockLocationOrderpoint(models.Model):
                     picking.priority = new_priority
 
         return self._strategy_model._after_run_replenishment(
-            self.location_id, replenishment_moves
+            self.location, replenishment_moves
         )
 
     def _assign_replenishment_moves(self, moves_to_assign):
@@ -817,8 +788,6 @@ class StockLocationOrderpoint(models.Model):
 
     def _clear_caches(self):
         self._get_ids_by_parent_path.clear_cache(self)
-        self._get_src_domains.clear_cache(self)
-        self._get_dest_domains.clear_cache(self)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -503,18 +503,26 @@ class StockLocationOrderpoint(models.Model):
         self._assign_replenishment_moves(
             replenishment_moves.filtered(lambda m: m.state != "assigned")
         )
-        picking_priority_to_update = env["stock.picking"]
+        picking_priority_to_update = self.env["stock.picking"]
         for move in replenishment_moves.sudo():
             new_priority = move.location_orderpoint_id.priority
             if move.priority != new_priority:
                 move.priority = new_priority
                 picking_priority_to_update |= move.picking_id
         for picking in picking_priority_to_update:
-             new_priority = max(picking.move_ids.filtered(lambda m: m.state != "cancel").priority)
-             if picking.priority != new_priority:
-                picking.priority = new_priority
-
-
+            new_priority = max(
+                picking.move_ids.filtered(lambda m: m.state != "cancel").mapped(
+                    "priority"
+                )
+            )
+            if picking.priority != new_priority:
+                # we want to avoid to override the individual move priority by the
+                # picking priority, so we protect the priority field on the
+                # picking's moves
+                with self.env.protecting(
+                    [self.env["stock.move"]._fields["priority"]], picking.move_ids
+                ):
+                    picking.priority = new_priority
 
     def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -8,6 +8,7 @@ from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
 from odoo.osv import expression
 from odoo.tools import split_every
+from odoo.tools.safe_eval import safe_eval
 
 from odoo.addons.queue_job.job import identity_exact
 
@@ -83,6 +84,11 @@ class StockLocationOrderpoint(models.Model):
     )
     location_src_id = fields.Many2one(
         "stock.location", compute="_compute_location_src_id", store=True
+    )
+    product_domain_char = fields.Char(
+        string="Product domain",
+        help="Additional domain to filter products for this orderpoint. ",
+        default="[]",
     )
     replenish_limit_to_free_qty = fields.Boolean(
         string="Limit replenishment to free quantity at source location",
@@ -182,6 +188,10 @@ class StockLocationOrderpoint(models.Model):
     # -------------------------------------------------------------------------
     # Orderpoint selection and domains
     # -------------------------------------------------------------------------
+
+    def _get_product_domain(self):
+        self.ensure_one()
+        return safe_eval(self.product_domain_char) if self.product_domain_char else []
 
     def _prepare_orderpoint_domain_location(
         self, location_ids, location_field="location_id"
@@ -285,6 +295,12 @@ class StockLocationOrderpoint(models.Model):
         """Group impacted products by orderpoint using a domain provider."""
         products_by_orderpoint = defaultdict(self.env["product.product"].browse)
         for orderpoint in orderpoints:
+            product_domain = orderpoint._get_product_domain()
+            if product_domain:
+                authorized_product = moves.mapped("product_id").filtered_domain(
+                    product_domain
+                )
+                moves = moves.filtered(lambda m: m.product_id in authorized_product)
             moves_for_orderpoint = moves.filtered_domain(
                 get_moves_domain(orderpoint.id)
             )
@@ -403,6 +419,7 @@ class StockLocationOrderpoint(models.Model):
             "horizon": self._horizon_datetime,
             "replenish_limit_to_free_qty": self.replenish_limit_to_free_qty,
             "excluded_location_domain": self.stock_excluded_location_domain,
+            "product_domain": self._get_product_domain(),
         }
 
     # -------------------------------------------------------------------------
@@ -571,7 +588,10 @@ class StockLocationOrderpoint(models.Model):
         """
         self.ensure_one()
         return self._strategy_model._get_candidate_products(
-            self.location_id, self._horizon_datetime, products=products
+            self.location_id,
+            self._horizon_datetime,
+            self._get_product_domain(),
+            products=products,
         )
 
     def _build_procurements(self, procurement_data):

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -91,6 +91,13 @@ class StockLocationOrderpoint(models.Model):
         "limited to the free quantity at the source location. ",
         default=True,
     )
+    replenish_horizon = fields.Float(
+        string="Replenishment horizon (in days)",
+        help="Time horizon to consider for the replenishment. "
+        "Limits the demand considered to what is expected in the horizon. ",
+        default=7,
+        required=True,
+    )
     active = fields.Boolean(default=True)
 
     last_cron_execution = fields.Datetime(
@@ -118,6 +125,17 @@ class StockLocationOrderpoint(models.Model):
             "The combination of Company, Location, Route and Replenish method must be unique",
         )
     ]
+
+    # -------------------------------------------------------------------------
+    # Simple properties
+    # -------------------------------------------------------------------------
+
+    @property
+    def _horizon_datetime(self):
+        """Compute the replenishment horizon as a datetime based on the current time and the
+        replenish_horizon field expressed in days."""
+        self.ensure_one()
+        return fields.Datetime.add(fields.Datetime.now(), days=self.replenish_horizon)
 
     # -------------------------------------------------------------------------
     # Validation and computed fields
@@ -380,6 +398,7 @@ class StockLocationOrderpoint(models.Model):
         return {
             "location_id": self.location_id.id,
             "location_src_id": self.location_src_id.id,
+            "horizon": self._horizon_datetime,
             "replenish_limit_to_free_qty": self.replenish_limit_to_free_qty,
             "excluded_location_domain": self.stock_excluded_location_domain,
         }
@@ -550,7 +569,7 @@ class StockLocationOrderpoint(models.Model):
         """
         self.ensure_one()
         return self._strategy_model._get_candidate_products(
-            self.location_id, products=products
+            self.location_id, self._horizon_datetime, products=products
         )
 
     def _build_procurements(self, procurement_data):

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -503,12 +503,18 @@ class StockLocationOrderpoint(models.Model):
         self._assign_replenishment_moves(
             replenishment_moves.filtered(lambda m: m.state != "assigned")
         )
+        picking_priority_to_update = env["stock.picking"]
         for move in replenishment_moves.sudo():
             new_priority = move.location_orderpoint_id.priority
-            if move.picking_id.priority != new_priority:
-                move.picking_id.priority = new_priority
             if move.priority != new_priority:
                 move.priority = new_priority
+                picking_priority_to_update |= move.picking_id
+        for picking in picking_priority_to_update:
+             new_priority = max(picking.move_ids.filtered(lambda m: m.state != "cancel").priority)
+             if picking.priority != new_priority:
+                picking.priority = new_priority
+
+
 
     def _prepare_orderpoint_domain_location(self, location_ids, location_field=False):
         """

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -127,7 +127,12 @@ class StockLocationOrderpoint(models.Model):
             "location_route_unique",
             "unique(location_id, route_id, company_id, replenish_method)",
             "The combination of Company, Location, Route and Replenish method must be unique",
-        )
+        ),
+        (
+            "name_unique",
+            "unique(name, company_id)",
+            "The Orderpoint name must be unique per company",
+        ),
     ]
 
     def _selection_move_priorities(self):

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -264,7 +264,6 @@ class StockLocationOrderpoint(models.Model):
         )
 
     @api.model
-    @tools.ormcache("orderpoint_id")
     def _get_consuming_moves_domain(self, orderpoint_id):
         (
             _q,
@@ -277,7 +276,6 @@ class StockLocationOrderpoint(models.Model):
         return expression.AND([domain_move_out_loc, domain])
 
     @api.model
-    @tools.ormcache("orderpoint_id")
     def _get_supplying_moves_domain(self, orderpoint_id):
         (
             _q,
@@ -819,8 +817,6 @@ class StockLocationOrderpoint(models.Model):
 
     def _clear_caches(self):
         self._get_ids_by_parent_path.clear_cache(self)
-        self._get_consuming_moves_domain.clear_cache(self)
-        self._get_supplying_moves_domain.clear_cache(self)
         self._get_src_domains.clear_cache(self)
         self._get_dest_domains.clear_cache(self)
 

--- a/stock_location_orderpoint/models/stock_location_orderpoint_strategy.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint_strategy.py
@@ -9,13 +9,14 @@ class StockLocationOrderpointStrategy(models.AbstractModel):
     _description = "Stock location orderpoint strategy"
 
     @api.model
-    def _get_candidate_products(self, location, horizon, products=None):
+    def _get_candidate_products(self, location, horizon, product_domain, products=None):
         """
         Get the candidate products to compute the demand for according to a specific strategy.
         By default, we consider that all stockable products are candidates.
 
         :param location: stock.location record
         :param horizon: datetime, time horizon to consider for the replenishment
+        :param product_domain: domain to filter products
         :param products: product.product recordset or None
 
          :return: product.product recordset
@@ -28,18 +29,29 @@ class StockLocationOrderpointStrategy(models.AbstractModel):
         )
 
     @api.model
-    def _compute_demand(self, location, horizon, products) -> dict[int, float]:
+    def _compute_demand(
+        self, location, horizon, product_domain, products
+    ) -> dict[int, float]:
         """
         Compute demand for the given products according to a specific strategy.
 
         :param location: stock.location record
         :param horizon: datetime, time horizon to consider for the replenishment
-        :param products: product.product recordset
+        :param product_domain: domain to filter products
+        :param products: product.product recordset or None
 
         :return: dict {product_id: demand_qty}
 
         This model is meant to be inherited to implement different strategies
         to compute the demand.
+
+        In some cases, the candidate products could be computed directly from the demand
+        computation. In such case, the _get_candidate_products method of the strategy will
+        return None and the _compute_demand method will be responsible to compute the
+         candidate products and the demand at the same time. That's why the _compute_demand
+         method receives the same parameters as the _get_candidate_products method, to be
+         able to compute the candidate products if needed.
+
         The demand is the quantity to replenish to meet the orderpoint's rules.
         """
         raise NotImplementedError(

--- a/stock_location_orderpoint/models/stock_location_orderpoint_strategy.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint_strategy.py
@@ -1,0 +1,58 @@
+# Copyright 2026 ACSONE SA/NV (https://www.acsone.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class StockLocationOrderpointStrategy(models.AbstractModel):
+    _name = "stock.location.orderpoint.strategy"
+    _description = "Stock location orderpoint strategy"
+
+    @api.model
+    def _get_candidate_products(self, location, products=None):
+        """
+        Get the candidate products to compute the demand for according to a specific strategy.
+        By default, we consider that all stockable products are candidates.
+
+        :param location: stock.location record
+        :param products: product.product recordset or None
+
+         :return: product.product recordset
+
+        When the method is called with products, it's responsible to filter
+        them according to the strategy logic.
+        """
+        raise NotImplementedError(
+            "The _get_candidate_products method should be implemented in the strategy"
+        )
+
+    @api.model
+    def _compute_demand(self, location, products) -> dict[int, float]:
+        """
+        Compute demand for the given products according to a specific strategy.
+
+        :param location: stock.location record
+        :param products: product.product recordset
+
+        :return: dict {product_id: demand_qty}
+
+        This model is meant to be inherited to implement different strategies
+        to compute the demand.
+        The demand is the quantity to replenish to meet the orderpoint's rules.
+        """
+        raise NotImplementedError(
+            "The _compute_demand method should be implemented in the strategy."
+        )
+
+    @api.model
+    def _after_run_replenishment(self, location, replenishment_moves):
+        """
+        Method called after the replenishment moves have been created for an orderpoint.
+        This allows to implement specific logic after the replenishment, like changing the
+        priority of the replenishment moves according to the strategy.
+
+        :param location: stock.location record
+        :param replenishment_moves: stock.move recordset of the replenishment moves that
+        have been created
+        """
+        return replenishment_moves

--- a/stock_location_orderpoint/models/stock_location_orderpoint_strategy.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint_strategy.py
@@ -9,12 +9,13 @@ class StockLocationOrderpointStrategy(models.AbstractModel):
     _description = "Stock location orderpoint strategy"
 
     @api.model
-    def _get_candidate_products(self, location, products=None):
+    def _get_candidate_products(self, location, horizon, products=None):
         """
         Get the candidate products to compute the demand for according to a specific strategy.
         By default, we consider that all stockable products are candidates.
 
         :param location: stock.location record
+        :param horizon: datetime, time horizon to consider for the replenishment
         :param products: product.product recordset or None
 
          :return: product.product recordset
@@ -27,11 +28,12 @@ class StockLocationOrderpointStrategy(models.AbstractModel):
         )
 
     @api.model
-    def _compute_demand(self, location, products) -> dict[int, float]:
+    def _compute_demand(self, location, horizon, products) -> dict[int, float]:
         """
         Compute demand for the given products according to a specific strategy.
 
         :param location: stock.location record
+        :param horizon: datetime, time horizon to consider for the replenishment
         :param products: product.product recordset
 
         :return: dict {product_id: demand_qty}

--- a/stock_location_orderpoint/models/stock_location_orderpoint_strategy_fill_up.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint_strategy_fill_up.py
@@ -11,7 +11,7 @@ class StockLocationOrderpointStrategyFillUp(models.AbstractModel):
     _description = "Stock location orderpoint strategy: fill up to the max quantity"
 
     @api.model
-    def _get_candidate_products(self, location, products=None):
+    def _get_candidate_products(self, location, horizon, products=None):
         """
         In the fill-up strategy, if the orderpoint is triggered without specifying products,
         we want to consider only the products with pending not fully reserved moves
@@ -21,6 +21,7 @@ class StockLocationOrderpointStrategyFillUp(models.AbstractModel):
         demand for this product at the destination location.
 
         :param location: stock.location record
+        :param horizon: dateime, time horizon to consider for the replenishment
         :param products: product.product recordset or None
 
         :return: product.product recordset
@@ -45,7 +46,7 @@ class StockLocationOrderpointStrategyFillUp(models.AbstractModel):
         return self.env["product.product"].browse(product_ids)
 
     @api.model
-    def _compute_demand(self, location, products) -> dict[int, float]:
+    def _compute_demand(self, location, horizon, products) -> dict[int, float]:
         """
         Compute demand for the given products according to the fill-up strategy.
         The demand is computed as the quantity required to ensure that the
@@ -54,12 +55,13 @@ class StockLocationOrderpointStrategyFillUp(models.AbstractModel):
         location and the quantity already incoming.
 
         :param location: stock.location record
+        :param horizon: datetime, time horizon to consider for the replenishment
         :param products: product.product recordset
         """
         demand_data = {}
         qties_on_location = products.with_context(
             location=location.id
-        )._compute_quantities_dict(None, None, None)
+        )._compute_quantities_dict(None, None, None, to_date=horizon)
         for product_id, qties_on_location in qties_on_location.items():
             virtual_available_on_dest = qties_on_location["virtual_available"]
             if (

--- a/stock_location_orderpoint/models/stock_location_orderpoint_strategy_fill_up.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint_strategy_fill_up.py
@@ -11,7 +11,7 @@ class StockLocationOrderpointStrategyFillUp(models.AbstractModel):
     _description = "Stock location orderpoint strategy: fill up to the max quantity"
 
     @api.model
-    def _get_candidate_products(self, location, horizon, products=None):
+    def _get_candidate_products(self, location, horizon, product_domain, products=None):
         """
         In the fill-up strategy, if the orderpoint is triggered without specifying products,
         we want to consider only the products with pending not fully reserved moves
@@ -21,12 +21,15 @@ class StockLocationOrderpointStrategyFillUp(models.AbstractModel):
         demand for this product at the destination location.
 
         :param location: stock.location record
-        :param horizon: dateime, time horizon to consider for the replenishment
+        :param horizon: datetime, time horizon to consider for the replenishment
+        :param product_domain: domain to filter products
         :param products: product.product recordset or None
 
         :return: product.product recordset
         """
         if products:
+            if product_domain:
+                products = products.filtered_domain(product_domain)
             return products
         domain_move = self.env["stock.location"]._get_consuming_moves_domain(
             location.id
@@ -35,18 +38,43 @@ class StockLocationOrderpointStrategyFillUp(models.AbstractModel):
         stock_move_obj._flush_search(domain_move)
         query = stock_move_obj._where_calc(domain_move)
         stock_move_obj._apply_ir_rules(query, "read")
+
+        if product_domain:
+            product_obj = self.env["product.product"]
+            product_obj._flush_search(product_domain)
+            product_query = product_obj._where_calc(product_domain)
+            product_obj._apply_ir_rules(product_query, "read")
+
         from_clause, where_clause, params = query.get_sql()
         sql = f"""
             SELECT DISTINCT product_id
             FROM {from_clause}
             WHERE {where_clause}
         """
+        if product_domain:
+            (
+                from_clause_product,
+                where_clause_product,
+                params_product,
+            ) = product_query.get_sql()
+            sql += f"""
+                AND EXISTS (
+                    SELECT 1
+                    FROM {from_clause_product}
+                    WHERE {where_clause_product}
+                    AND product_product.id = stock_move.product_id
+                )
+            """
+            params += params_product
+
         self.env.cr.execute(sql, params)
         product_ids = [row[0] for row in self.env.cr.fetchall()]
         return self.env["product.product"].browse(product_ids)
 
     @api.model
-    def _compute_demand(self, location, horizon, products) -> dict[int, float]:
+    def _compute_demand(
+        self, location, horizon, product_domain, products
+    ) -> dict[int, float]:
         """
         Compute demand for the given products according to the fill-up strategy.
         The demand is computed as the quantity required to ensure that the
@@ -56,8 +84,11 @@ class StockLocationOrderpointStrategyFillUp(models.AbstractModel):
 
         :param location: stock.location record
         :param horizon: datetime, time horizon to consider for the replenishment
-        :param products: product.product recordset
+        :param product_domain: domain to filter products
+        :param products: product.product recordset or None
         """
+        # we ignore the domain since the domain is already applied in
+        # the _get_candidate_products method
         demand_data = {}
         qties_on_location = products.with_context(
             location=location.id

--- a/stock_location_orderpoint/models/stock_location_orderpoint_strategy_fill_up.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint_strategy_fill_up.py
@@ -31,9 +31,7 @@ class StockLocationOrderpointStrategyFillUp(models.AbstractModel):
             if product_domain:
                 products = products.filtered_domain(product_domain)
             return products
-        domain_move = self.env["stock.location"]._get_consuming_moves_domain(
-            location.id
-        )
+        domain_move = location._get_consuming_moves_domain()
         stock_move_obj = self.env["stock.move"]
         stock_move_obj._flush_search(domain_move)
         query = stock_move_obj._where_calc(domain_move)
@@ -119,9 +117,7 @@ class StockLocationOrderpointStrategyFillUp(models.AbstractModel):
         replenishment_moves = super()._after_run_replenishment(
             location, replenishment_moves
         )
-        domain_move = self.env["stock.location"]._get_consuming_moves_domain(
-            location.id
-        )
+        domain_move = location._get_consuming_moves_domain()
         stock_move_obj = self.env["stock.move"]
         stock_move_obj._flush_search(domain_move)
         stock_move_obj.flush_model(["date"])

--- a/stock_location_orderpoint/models/stock_location_orderpoint_strategy_fill_up.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint_strategy_fill_up.py
@@ -1,0 +1,118 @@
+# Copyright 2026 ACSONE SA/NV (https://www.acsone.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+from odoo.tools import float_compare
+
+
+class StockLocationOrderpointStrategyFillUp(models.AbstractModel):
+    _inherit = "stock.location.orderpoint.strategy"
+    _name = "stock.location.orderpoint.strategy.fill_up"
+    _description = "Stock location orderpoint strategy: fill up to the max quantity"
+
+    @api.model
+    def _get_candidate_products(self, location, products=None):
+        """
+        In the fill-up strategy, if the orderpoint is triggered without specifying products,
+        we want to consider only the products with pending not fully reserved moves
+        from the destination location of the orderpoint as candidates to compute the demand for.
+        This is because the fill-up strategy is meant to fill up the stock at the destination
+        location, and if there are no pending moves for a product, it means that there is no
+        demand for this product at the destination location.
+
+        :param location: stock.location record
+        :param products: product.product recordset or None
+
+        :return: product.product recordset
+        """
+        if products:
+            return products
+        domain_move = self.env["stock.location"]._get_consuming_moves_domain(
+            location.id
+        )
+        stock_move_obj = self.env["stock.move"]
+        stock_move_obj._flush_search(domain_move)
+        query = stock_move_obj._where_calc(domain_move)
+        stock_move_obj._apply_ir_rules(query, "read")
+        from_clause, where_clause, params = query.get_sql()
+        sql = f"""
+            SELECT DISTINCT product_id
+            FROM {from_clause}
+            WHERE {where_clause}
+        """
+        self.env.cr.execute(sql, params)
+        product_ids = [row[0] for row in self.env.cr.fetchall()]
+        return self.env["product.product"].browse(product_ids)
+
+    @api.model
+    def _compute_demand(self, location, products) -> dict[int, float]:
+        """
+        Compute demand for the given products according to the fill-up strategy.
+        The demand is computed as the quantity required to ensure that the
+        virtual available quantity is not negative, i.e. to fill
+        up the stock up to 0. according to the quantity available at source
+        location and the quantity already incoming.
+
+        :param location: stock.location record
+        :param products: product.product recordset
+        """
+        demand_data = {}
+        qties_on_location = products.with_context(
+            location=location.id
+        )._compute_quantities_dict(None, None, None)
+        for product_id, qties_on_location in qties_on_location.items():
+            virtual_available_on_dest = qties_on_location["virtual_available"]
+            if (
+                float_compare(
+                    virtual_available_on_dest,
+                    0,
+                    precision_rounding=self.env["product.product"]
+                    .browse(product_id)
+                    .uom_id.rounding,
+                )
+                >= 0
+            ):
+                continue
+            demand_data[product_id] = abs(virtual_available_on_dest)
+        return demand_data
+
+    @api.model
+    def _after_run_replenishment(self, location, replenishment_moves):
+        """In the fill-up strategy, we want to set the date of the replenishment moves
+        to the earliest date of the pending moves for the same product and the same
+        destination location, to ensure that the replenishment is done in time to meet
+        the demand of these pending moves.
+        """
+        replenishment_moves = super()._after_run_replenishment(
+            location, replenishment_moves
+        )
+        domain_move = self.env["stock.location"]._get_consuming_moves_domain(
+            location.id
+        )
+        stock_move_obj = self.env["stock.move"]
+        stock_move_obj._flush_search(domain_move)
+        stock_move_obj.flush_model(["date"])
+        query = stock_move_obj._where_calc(domain_move)
+        stock_move_obj._apply_ir_rules(query, "read")
+        from_clause, where_clause, params = query.get_sql()
+        sql = f"""
+            SELECT product_id,
+                  min (date)
+            FROM {from_clause}
+            WHERE {where_clause}
+            GROUP BY product_id
+        """
+        self.env.cr.execute(sql, params)
+        dates_by_product = {row[0]: row[1] for row in self.env.cr.fetchall()}
+        picking_change_date_ids = set()
+        for move in replenishment_moves:
+            if move.product_id.id not in dates_by_product:
+                continue
+            move.date = dates_by_product[move.product_id.id]
+            picking_change_date_ids.add(move.picking_id.id)
+        pickings = self.env["stock.picking"].browse(picking_change_date_ids)
+        for picking in pickings:
+            picking_date = min(picking.move_ids.mapped("date"))
+            if picking_date < picking.scheduled_date:
+                picking.scheduled_date = picking_date
+        return replenishment_moves

--- a/stock_location_orderpoint/models/stock_location_replenishment_computer.py
+++ b/stock_location_orderpoint/models/stock_location_replenishment_computer.py
@@ -49,6 +49,12 @@ class StockLocationReplenishmentComputer(models.TransientModel):
         required=True,
         string="Source Location",
     )
+    horizon = fields.Datetime(
+        required=True,
+        string="Horizon Datetime",
+        help="Time horizon to consider for the replenishment. Only moves with a date_deadline"
+        "up to this datetime will be considered in the demand computation.",
+    )
     replenish_limit_to_free_qty = fields.Boolean(
         default=True,
     )
@@ -129,7 +135,7 @@ class StockLocationReplenishmentComputer(models.TransientModel):
             location = location.with_context(
                 excluded_location_domain=self.excluded_location_domain
             )
-        return self._strategy._compute_demand(location, products)
+        return self._strategy._compute_demand(location, self.horizon, products)
 
     def _compute_procurement_qty(self, demand_data, job_logs=None):
         """

--- a/stock_location_orderpoint/models/stock_location_replenishment_computer.py
+++ b/stock_location_orderpoint/models/stock_location_replenishment_computer.py
@@ -1,0 +1,273 @@
+# Copyright 2026 ACSONE SA/NV (https://www.acsone.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import _, fields, models
+from odoo.osv import expression
+from odoo.tools import float_compare
+
+
+class StockLocationReplenishmentComputer(models.TransientModel):
+    """
+    Orderpoint-agnostic replenishment computation engine.
+
+    Instantiated in memory via `new()` — no DB persistence — so it can be
+    used for any (location, location_src, strategy) combination without
+    requiring an orderpoint record to exist.
+
+    The strategy is injected at instantiation time via _strategy, which
+    decouples the computer from any replenish_method resolution logic.
+    Adding a new strategy never requires modifying this class.
+
+    Typical usage from an orderpoint::
+
+        computer = orderpoint._get_replenishment_computer()
+        procurement_data = computer.compute(products=products, demand_only=False)
+
+    Usage independent of any orderpoint::
+
+        computer = self.env["stock.location.replenishment.computer"].new({
+            "location_id": some_location.id,
+            "location_src_id": some_src.id,
+            "replenish_limit_to_free_qty": True,
+            "excluded_location_domain": [...],
+        })
+        computer._strategy = self.env["stock.location.orderpoint.strategy.fill_up"]
+        qty_by_product = computer.compute()
+    """
+
+    _name = "stock.location.replenishment.computer"
+    _description = "Stock Location Replenishment Computer"
+
+    __slots__ = ["__strategy"]
+
+    location_id = fields.Many2one(
+        "stock.location",
+        required=True,
+        string="Destination Location",
+    )
+    location_src_id = fields.Many2one(
+        "stock.location",
+        required=True,
+        string="Source Location",
+    )
+    replenish_limit_to_free_qty = fields.Boolean(
+        default=True,
+    )
+    excluded_location_domain = fields.Json(
+        default=False,
+        help="Optional domain to exclude some locations from availability computation. ",
+    )
+
+    # Strategy instance injected after new() — never persisted.
+    # Set explicitly before calling compute():
+    #   computer._strategy = orderpoint._strategy_model
+
+    @property
+    def _strategy(self):
+        if self.__strategy is None:
+            raise ValueError(
+                "StockLocationReplenishmentComputer._strategy must be set before use"
+            )
+        return self.__strategy
+
+    @_strategy.setter
+    def _strategy(self, value):
+        self.__strategy = value
+
+    # -------------------------------------------------------------------------
+    # Public entry point
+    # -------------------------------------------------------------------------
+
+    def compute(self, products=None, demand_only=False, job_logs=None):
+        """
+        Compute replenishment quantities for the given products.
+
+        :param products: optional product.product recordset to scope the
+            computation. If None, the strategy determines the candidates.
+        :param demand_only: if True, stop after demand computation and return
+            {product_id: demand_qty} without the availability cap.
+            Used by the async path in _run_replenishment so that one job per
+            product can be enqueued after a single demand pass, with no
+            double calculation.
+        :param job_logs: optional list to collect trace messages.
+
+        :return: dict {product_id: demand_qty}       if demand_only=True
+                 dict {product_id: qty_to_procure}   if demand_only=False
+        """
+        self.ensure_one()
+        demand_data = self._compute_demand(products)
+        if job_logs is not None:
+            job_logs.append(
+                _(
+                    "Demand computed for location %(location)s: %(count)s products.",
+                    location=self.location_id.display_name,
+                    count=len(demand_data),
+                )
+            )
+
+        if not demand_data or demand_only:
+            return demand_data or {}
+
+        return self._compute_procurement_qty(demand_data, job_logs=job_logs)
+
+    # -------------------------------------------------------------------------
+    # Computation pipeline
+    # -------------------------------------------------------------------------
+
+    def _compute_demand(self, products=None):
+        """
+        Compute demand for the given products via the injected strategy.
+
+        :return: dict {product_id: demand_qty}
+        """
+        self.ensure_one()
+        location = self.location_id
+        if self.excluded_location_domain:
+            if products is not None:
+                products = products.with_context(
+                    excluded_location_domain=self.excluded_location_domain
+                )
+            location = location.with_context(
+                excluded_location_domain=self.excluded_location_domain
+            )
+        return self._strategy._compute_demand(location, products)
+
+    def _compute_procurement_qty(self, demand_data, job_logs=None):
+        """
+        Cap demand to available quantity at the source location.
+
+        The availability check and the qty decision are kept together
+        intentionally: splitting them across separate transactions can
+        lead to over-replenishment when multiple orderpoints share the
+        same source location.
+
+        If replenish_limit_to_free_qty is False, returns demand_data as-is.
+
+        :param demand_data: dict {product_id: demand_qty}
+        :return: dict {product_id: qty_to_procure}
+        """
+        self.ensure_one()
+        if not self.replenish_limit_to_free_qty:
+            return demand_data
+
+        product_ids = list(demand_data.keys())
+        qty_available_data = self._compute_available_quantities(product_ids)
+
+        # prefetch product_ids for uom_id access in float_compare
+        self.env["product.product"].browse(qty_available_data.keys())
+
+        result = {
+            product_id: qty
+            for product_id in demand_data
+            if (
+                qty := min(
+                    demand_data[product_id], qty_available_data.get(product_id, 0)
+                )
+            )
+            and float_compare(
+                qty,
+                0,
+                precision_rounding=self.env["product.product"]
+                .browse(product_id)
+                .uom_id.rounding,
+            )
+            == 1
+        }
+        if job_logs is not None:
+            job_logs.append(
+                _(
+                    "Procurement qty computed for location %(location)s: "
+                    "%(count)s products after availability cap.",
+                    location=self.location_id.display_name,
+                    count=len(result),
+                )
+            )
+        return result
+
+    def _compute_available_quantities(self, product_ids):
+        """
+        Compute available quantities at location_src for the given products.
+
+        Available qty = stock quant quantities
+                      - outgoing confirmed/assigned/partially_available moves
+
+        :param product_ids: list of product IDs to compute availability for
+        :return: dict {product_id: qty_available}
+        """
+        self.ensure_one()
+        location_model = self.env["stock.location"]
+        if self.excluded_location_domain:
+            location_model = location_model.with_context(
+                excluded_location_domain=self.excluded_location_domain
+            )
+
+        (
+            quant_domain,
+            _move_in_domain,
+            move_out_domain,
+        ) = location_model._get_stock_domains(self.location_src_id.id)
+
+        if len(product_ids) < 500:
+            # IN query too expensive with large product sets — skip when possible
+            quant_domain = expression.AND(
+                [quant_domain, [("product_id", "in", product_ids)]]
+            )
+            move_out_domain = expression.AND(
+                [move_out_domain, [("product_id", "in", product_ids)]]
+            )
+        move_out_domain = expression.AND(
+            [
+                move_out_domain,
+                [
+                    (
+                        "state",
+                        "in",
+                        ("confirmed", "assigned", "partially_available"),
+                    )
+                ],
+            ]
+        )
+
+        # --- STOCK MOVE (OUTGOING) ---
+        stock_move_obj = self.env["stock.move"]
+        stock_move_obj._flush_search(move_out_domain)
+        stock_move_obj.flush_model(["product_uom_qty"])
+        move_query = stock_move_obj._where_calc(move_out_domain)
+        stock_move_obj._apply_ir_rules(move_query, "read")
+        move_tables, move_where, move_params = move_query.get_sql()
+        move_sql = f"""
+            SELECT
+                {stock_move_obj._table}.product_id,
+                - SUM({stock_move_obj._table}.product_uom_qty) AS qty
+            FROM {move_tables}
+            WHERE {move_where}
+            GROUP BY {stock_move_obj._table}.product_id
+        """
+
+        # --- STOCK QUANT ---
+        stock_quant_obj = self.env["stock.quant"]
+        stock_quant_obj._flush_search(quant_domain)
+        stock_quant_obj.flush_model(["quantity"])
+        quant_query = stock_quant_obj._where_calc(quant_domain)
+        stock_quant_obj._apply_ir_rules(quant_query, "read")
+        quant_tables, quant_where, quant_params = quant_query.get_sql()
+        quant_sql = f"""
+            SELECT
+                {stock_quant_obj._table}.product_id,
+                SUM({stock_quant_obj._table}.quantity) AS qty
+            FROM {quant_tables}
+            WHERE {quant_where}
+            GROUP BY {stock_quant_obj._table}.product_id
+        """
+
+        # --- UNION ---
+        final_sql = f"""
+            SELECT product_id, SUM(qty) AS qty
+            FROM (
+                {move_sql}
+                UNION ALL
+                {quant_sql}
+            ) AS combined
+            GROUP BY product_id
+        """
+        self.env.cr.execute(final_sql, move_params + quant_params)
+        return dict(self.env.cr.fetchall())

--- a/stock_location_orderpoint/models/stock_location_replenishment_computer.py
+++ b/stock_location_orderpoint/models/stock_location_replenishment_computer.py
@@ -82,6 +82,22 @@ class StockLocationReplenishmentComputer(models.TransientModel):
     def _strategy(self, value):
         self.__strategy = value
 
+    @property
+    def location(self):
+        """Return the location_id with the excluded_location_domain applied in context."""
+        self.ensure_one()
+        return self.location_id.with_context(
+            excluded_location_domain=self.excluded_location_domain
+        )
+
+    @property
+    def location_src(self):
+        """Return the location_src_id with the excluded_location_domain applied in context."""
+        self.ensure_one()
+        return self.location_src_id.with_context(
+            excluded_location_domain=self.excluded_location_domain
+        )
+
     # -------------------------------------------------------------------------
     # Public entry point
     # -------------------------------------------------------------------------
@@ -129,17 +145,13 @@ class StockLocationReplenishmentComputer(models.TransientModel):
         :return: dict {product_id: demand_qty}
         """
         self.ensure_one()
-        location = self.location_id
         if self.excluded_location_domain:
             if products is not None:
                 products = products.with_context(
                     excluded_location_domain=self.excluded_location_domain
                 )
-            location = location.with_context(
-                excluded_location_domain=self.excluded_location_domain
-            )
         return self._strategy._compute_demand(
-            location, self.horizon, self.product_domain, products
+            self.location, self.horizon, self.product_domain, products
         )
 
     def _compute_procurement_qty(self, demand_data, job_logs=None):
@@ -205,17 +217,11 @@ class StockLocationReplenishmentComputer(models.TransientModel):
         :return: dict {product_id: qty_available}
         """
         self.ensure_one()
-        location_model = self.env["stock.location"]
-        if self.excluded_location_domain:
-            location_model = location_model.with_context(
-                excluded_location_domain=self.excluded_location_domain
-            )
-
         (
             quant_domain,
             _move_in_domain,
             move_out_domain,
-        ) = location_model._get_stock_domains(self.location_src_id.id)
+        ) = self.location_src._get_stock_domains()
 
         if len(product_ids) < 500:
             # IN query too expensive with large product sets — skip when possible

--- a/stock_location_orderpoint/models/stock_location_replenishment_computer.py
+++ b/stock_location_orderpoint/models/stock_location_replenishment_computer.py
@@ -62,6 +62,9 @@ class StockLocationReplenishmentComputer(models.TransientModel):
         default=False,
         help="Optional domain to exclude some locations from availability computation. ",
     )
+    product_domain = fields.Binary(
+        default=[], help="Optional domain to filter products"
+    )
 
     # Strategy instance injected after new() — never persisted.
     # Set explicitly before calling compute():
@@ -135,7 +138,9 @@ class StockLocationReplenishmentComputer(models.TransientModel):
             location = location.with_context(
                 excluded_location_domain=self.excluded_location_domain
             )
-        return self._strategy._compute_demand(location, self.horizon, products)
+        return self._strategy._compute_demand(
+            location, self.horizon, self.product_domain, products
+        )
 
     def _compute_procurement_qty(self, demand_data, job_logs=None):
         """

--- a/stock_location_orderpoint/models/stock_move.py
+++ b/stock_location_orderpoint/models/stock_move.py
@@ -1,11 +1,13 @@
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# Copyright 2026 ACSONE SA/NV (https://www.acsone.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from collections import defaultdict
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.tools import ormcache
 
 from odoo.addons.queue_job.job import identity_exact
+
+from .tools import MovesTouchTracker
 
 
 class StockMove(models.Model):
@@ -22,70 +24,82 @@ class StockMove(models.Model):
         )
 
     def _prepare_auto_replenishment_for_outgoing_moves(self):
-        self._prepare_auto_replenishment("location_id")
+        products_by_orderpoint = self.env[
+            "stock.location.orderpoint"
+        ]._get_from_move_demand(self, trigger="auto")
+        self._prepare_run_replenishment(products_by_orderpoint)
 
     def _prepare_auto_replenishment_for_incoming_moves(self):
-        self._prepare_auto_replenishment("location_dest_id")
+        products_by_orderpoint = self.env[
+            "stock.location.orderpoint"
+        ]._get_from_move_supply(self, trigger="auto")
+        self._prepare_run_replenishment(products_by_orderpoint)
 
-    def _prepare_auto_replenishment(self, location_field):
+    def _prepare_run_replenishment(self, products_by_orderpoint):
         if not self or self.env.context.get("skip_auto_replenishment"):
             return
-        locations_products = defaultdict(set)
-        location_ids = set()
-        product_obj = self.env["product.product"]
-
-        moves = self.env[
-            "stock.location.orderpoint"
-        ]._filter_moves_triggering_orderpoints(self, trigger="auto")
-        for move in moves:
-            location = getattr(move, location_field)
-            locations_products[location].add(move.product_id.id)
-            location_ids.add(location.id)
-        # Map the the move's location field
-        # to the correspoding stock.location.orderpoint's location field
-        location_field = (
-            location_field == "location_id" and location_field or "location_src_id"
-        )
-        for location, products in locations_products.items():
-            # if not orderpoints._is_location_parent_of(location, location_field):
-            #    continue
-            for product in product_obj.browse(products):
-                self._enqueue_auto_replenishment(
-                    location, product, location_field
+        for orderpoint, products in products_by_orderpoint.items():
+            for product in products:
+                self._enqueue_run_replenishment(
+                    orderpoint,
+                    product,
                 ).delay()
 
-    def _enqueue_auto_replenishment(
-        self, location, product, location_field, **job_options
-    ):
-        """Enqueue a job stock.location.orderpoint.run_auto_replenishment()
+    def _enqueue_run_replenishment(self, orderpoint, product, **job_options):
+        """
+        Enqueue a replenishment job for a single (orderpoint, product) pair.
 
-        Can be extended to pass different options to the job (priority, ...).
-        The usage of `.setdefault` allows to override the options set by default.
+        This is the delay point for AUTO orderpoints. It fires *before* the
+        replenishment pipeline so that the full computation (candidate selection,
+        demand, available qty, procurement) only happens inside a worker, and
+        only for products whose move actually impacts an orderpoint. The identity
+        key deduplicates concurrent triggers for the same (orderpoint, product).
 
-        return: a `Job` instance
+        Design note — two delay mechanisms coexist intentionally:
+
+        1. This method (AUTO, delay before pipeline):
+           - Granularity: one job per (orderpoint × product).
+           - Purpose: avoid redundant demand calculations for products that do
+             not impact any orderpoint, and deduplicate concurrent stock.move
+             events that concern the same (orderpoint, product) pair.
+           - The entire _run_replenishment() pipeline runs synchronously inside
+             the worker; procurement execution is therefore also synchronous.
+
+        2. _enqueue_fulfill_procurement() (CRON / MANUAL, delay after demand):
+           - Granularity: one job per (orderpoint x product) that has
+             non-zero demand.
+           - Purpose: defer the costly fulfillment step while keeping the
+             availability check, procurement qty decision and procurement run
+             in the same worker transaction.
+           - Demand is computed in the caller transaction; each delayed job
+             then executes _fulfill_procurement(product_id, demand_qty).
+
+        Merging the two would require creating one job per candidate product
+        before demand is computed, producing tens of thousands of unnecessary
+        jobs on large databases (observed: 10,000+ jobs for ~300 actual
+        replenishments on a production database using the daily-sale strategy).
+
+        Can be extended to pass different options to the job (priority, …).
+        The usage of `.setdefault` allows callers to override the defaults.
+
+        :return: a Job instance (not yet delayed — caller must call .delay())
         """
         job_options = job_options.copy()
         job_options.setdefault(
             "description",
             _(
-                "Try to replenish quantities %(in_or_out)s location %(location_name)s "
+                "Try to replenish quantities in location %(location_name)s "
                 "for product %(product_name)s"
             )
             % {
-                "in_or_out": location_field == "location_id" and _("in") or _("from"),
-                "location_name": location.display_name,
+                "location_name": orderpoint.location_id.display_name,
                 "product_name": product.display_name,
             },
         )
         # do not enqueue 2 jobs for the same location and product set
         job_options.setdefault("identity_key", identity_exact)
-        delayable = self.env["stock.location.orderpoint"].delayable(**job_options)
-        job = delayable.run_auto_replenishment(
-            product,
-            location,
-            location_field,
-        )
-        return job
+        delayable = orderpoint.delayable(**job_options)
+        return delayable.run_replenishment(product)
 
     def _action_assign(self, *args, **kwargs):
         """This triggers the replenishment for new moves which are waiting for stock"""
@@ -94,7 +108,8 @@ class StockMove(models.Model):
         # location is decreased. So we need to trigger a check for replenishment
         # on this location IOW if an orderpoint exists for this location as
         # target location and the move has the expected characteristics (state, ...)
-        self._prepare_auto_replenishment_for_outgoing_moves()
+        if self:
+            self._prepare_auto_replenishment_for_outgoing_moves()
         return res
 
     def _action_done(self, *args, **kwargs):
@@ -108,7 +123,8 @@ class StockMove(models.Model):
         # on this location IOW if an orderpoint exists for this location
         # as source location and the move has the expected characteristics
         # (state, ...)
-        moves._prepare_auto_replenishment_for_incoming_moves()
+        if moves:
+            moves._prepare_auto_replenishment_for_incoming_moves()
         return moves
 
     def _merge_moves_fields(self):
@@ -119,3 +135,14 @@ class StockMove(models.Model):
             self, key=lambda x: x.location_orderpoint_id.priority
         ).location_orderpoint_id
         return res
+
+    @api.model_create_multi
+    @api.returns("self", lambda value: value.id)
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        MovesTouchTracker.add_ids(res.ids)
+        return res
+
+    def write(self, vals):
+        MovesTouchTracker.add_ids(self.ids)
+        return super().write(vals)

--- a/stock_location_orderpoint/models/stock_move.py
+++ b/stock_location_orderpoint/models/stock_move.py
@@ -110,3 +110,12 @@ class StockMove(models.Model):
         # (state, ...)
         moves._prepare_auto_replenishment_for_incoming_moves()
         return moves
+
+    def _merge_moves_fields(self):
+        # Make sure to link to the highest-priority orderpoint.
+        # This ensures the merged move inherits the correct priority
+        res = super()._merge_moves_fields()
+        res["location_orderpoint_id"] = max(
+            self, key=lambda x: x.location_orderpoint_id.priority
+        ).location_orderpoint_id
+        return res

--- a/stock_location_orderpoint/models/tools.py
+++ b/stock_location_orderpoint/models/tools.py
@@ -1,0 +1,32 @@
+# Copyright 2026 ACSONE SA/NV (https://www.acsone.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import contextvars
+
+
+class MovesTouchTracker:
+    """
+    Context manager to track stock moves that are created or updated during its execution.
+
+    This is useful for the stock location orderpoint module to determine which moves were
+    affected by the orderpoint processing, allowing it to post-process those moves after
+    their creation or update.
+    """
+
+    _current_move_ids = contextvars.ContextVar("current_touched_move_ids", default=None)
+
+    def __enter__(self):
+        self._token = self._current_move_ids.set(set())
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._current_move_ids.reset(self._token)
+
+    @classmethod
+    def add_ids(cls, ids):
+        current_moves = cls._current_move_ids.get()
+        if current_moves is not None:
+            current_moves.update(ids)
+
+    @classmethod
+    def get_ids(cls):
+        return cls._current_move_ids.get()

--- a/stock_location_orderpoint/readme/CONFIGURE.rst
+++ b/stock_location_orderpoint/readme/CONFIGURE.rst
@@ -53,3 +53,8 @@ Location Orderpoint configuration
    for product available quantities when triggering a replenishment (e.g.: Supplier locations - 
    to avoid confirmed receptions taken into account), fill in the 
    'Domain to filter locations' field.
+
+When different orderpoints are defined on the same location, it could result in the creation of several
+replenishment moves for the same product. When this happens, if the moves are merged together, the
+resulting move will be linked to the orderpoint with the highest priority, ensuring that the move 
+inherits the correct priority and is processed accordingly.

--- a/stock_location_orderpoint/readme/CONTRIBUTORS.rst
+++ b/stock_location_orderpoint/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 * Denis Roussel <denis.roussel@acsone.eu>
 * Nicolas Delbovier <nicolas.delbovier@acsone.eu>
+* Laurent Mignon <laurent.mignon@acsone.eu>

--- a/stock_location_orderpoint/readme/CONTRIBUTORS.rst
+++ b/stock_location_orderpoint/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Michael Tietz (MT Software) <mtietz@mt-software.de>
 * Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 * Denis Roussel <denis.roussel@acsone.eu>
+* Nicolas Delbovier <nicolas.delbovier@acsone.eu>

--- a/stock_location_orderpoint/security/ir.model.access.csv
+++ b/stock_location_orderpoint/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_stock_location_orderpoint_manager,stock.location.orderpoint - manager,model_stock_location_orderpoint,stock.group_stock_manager,1,1,1,1
 access_stock_location_orderpoint_user,stock.location.orderpoint - user,model_stock_location_orderpoint,stock.group_stock_user,1,0,0,0
+stock_location_orderpoint.access_stock_location_replenishment_computer,access_stock_location_replenishment_computer,stock_location_orderpoint.model_stock_location_replenishment_computer,base.group_user,1,0,0,0

--- a/stock_location_orderpoint/tests/__init__.py
+++ b/stock_location_orderpoint/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_location_orderpoint
+from . import test_location_orderpoint_priority
 from . import test_location_domain

--- a/stock_location_orderpoint/tests/common.py
+++ b/stock_location_orderpoint/tests/common.py
@@ -19,7 +19,16 @@ class TestLocationOrderpointCommon(BaseCommon):
             }
         )
         cls.warehouse = cls.env.ref("stock.warehouse0")
-        cls.location_dest = cls.warehouse.lot_stock_id
+        # isolate tests by creating a dedicated location instead of
+        # using the shared stock location to ensure that only the moves
+        # created in the test are considered by the orderpoint
+        cls.location_dest = cls.env["stock.location"].create(
+            {
+                "name": "Test Location",
+                "location_id": cls.warehouse.lot_stock_id.id,
+            }
+        )
+
         cls.env["stock.location.orderpoint"].search([]).write({"active": False})
 
     @classmethod
@@ -100,7 +109,7 @@ class TestLocationOrderpointCommon(BaseCommon):
         vals.update(kwargs)
         move = cls.env["stock.move"].create(vals)
         move._write({"create_date": datetime.now()})
-        move._action_confirm()
+        move._action_confirm(merge=False)
         return move
 
     @classmethod
@@ -121,19 +130,22 @@ class TestLocationOrderpointCommon(BaseCommon):
             cls.env.ref("stock.stock_location_suppliers"),
             location,
             product=product,
+            picking_type_id=cls.warehouse.in_type_id.id,
         )
         move.move_line_ids.write({"qty_done": qty})
         move._action_done()
         return move
 
     @classmethod
-    def _create_outgoing_move(cls, qty, location=None, product=None):
+    def _create_outgoing_move(cls, qty, location=None, product=None, **kwargs):
         move = cls._create_move(
             "Delivery",
             qty,
             location or cls.location_dest,
             cls.env.ref("stock.stock_location_customers"),
             product=product,
+            picking_type_id=cls.warehouse.out_type_id.id,
+            **kwargs,
         )
         move._action_assign()
         return move
@@ -196,7 +208,7 @@ class TestLocationOrderpointCommon(BaseCommon):
         cls, location_name, location_dest=None, warehouse=None, **kwargs
     ):
         location = cls._create_location(location_name, location_dest=location_dest)
-        picking_type, route = cls._create_picking_type_route_rule(
+        _picking_type, route = cls._create_picking_type_route_rule(
             location, location_dest=location_dest, warehouse=warehouse
         )
         values = kwargs or {}

--- a/stock_location_orderpoint/tests/test_location_domain.py
+++ b/stock_location_orderpoint/tests/test_location_domain.py
@@ -13,10 +13,10 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
         we need to exclude some locations from the available quantities (e.g.: Suppliers).
         """
         orderpoint, location_src = self._create_orderpoint_complete(
-            "Stock2", trigger="manual"
+            "Stock2", trigger="manual", proc_run_async=False
         )
         orderpoint2, location_src2 = self._create_orderpoint_complete(
-            "Stock2.2", trigger="manual"
+            "Stock2.2", trigger="manual", proc_run_async=False
         )
 
         orderpoint.stock_excluded_location_domain = [

--- a/stock_location_orderpoint/tests/test_location_orderpoint.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint.py
@@ -77,6 +77,23 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
         with self.assertRaises(ValidationError):
             self._create_orderpoint(route_id=self.warehouse.delivery_route_id)
 
+    def test_orderpoint_name_sequence(self):
+        sequence = self.env.ref(
+            "stock_location_orderpoint.sequence_location_orderpoint"
+        )
+        orderpoint1 = self._create_orderpoint(name="/")
+        orderpoint2 = self._create_orderpoint(name="/")
+        self.assertNotEqual(orderpoint1.name, orderpoint2.name)
+        self.assertTrue(orderpoint1.name.startswith(sequence.prefix))
+        self.assertTrue(orderpoint2.name.startswith(sequence.prefix))
+        # if I create a new orderpoint with a specific name, it should keep it
+        orderpoint3 = self._create_orderpoint(name="My custom name")
+        self.assertEqual(orderpoint3.name, "My custom name")
+        # if I update an orderpoint with name '/', it should get
+        # a new name from the sequence
+        orderpoint3.name = "/"
+        self.assertTrue(orderpoint3.name.startswith(sequence.prefix))
+
     def test_cron_replenishment(self):
         cron = self.env.ref("stock_location_orderpoint.ir_cron_location_replenishment")
         orderpoint, location_src = self._create_orderpoint_complete(

--- a/stock_location_orderpoint/tests/test_location_orderpoint.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint.py
@@ -9,7 +9,6 @@ from psycopg2 import IntegrityError
 from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tools import mute_logger
-from odoo.tools.date_utils import get_timedelta
 
 from odoo.addons.queue_job.job import identity_exact
 from odoo.addons.queue_job.tests.common import trap_jobs
@@ -97,12 +96,12 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
         self.assertFalse(replenish_move)
 
         # create the available quantity -> replenishment
-        tomorrow = now + get_timedelta(1, "day")
+        tomorrow = fields.Datetime.add(now, days=1)
         with self._freeze_time(tomorrow):
             self._set_qty_in_location(self.product, location_src, 12)
 
         self.product.invalidate_recordset()
-        day_after_tomorrow = now + get_timedelta(2, "day")
+        day_after_tomorrow = fields.Datetime.add(now, days=2)
         with self._freeze_time(day_after_tomorrow):
             cron.method_direct_trigger()
 

--- a/stock_location_orderpoint/tests/test_location_orderpoint.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint.py
@@ -147,6 +147,17 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
                 1, only=self.env["stock.location.orderpoint"]._fulfill_procurement
             )
 
+    def test_orderpoint_product_domain(self):
+        orderpoint, _location_src = self._create_orderpoint_complete(
+            "Stock2", trigger="manual", proc_run_async=False
+        )
+        self._create_outgoing_move(12, product=self.product)
+        candidate_products = orderpoint._get_candidate_products()
+        self.assertIn(self.product, candidate_products)
+        orderpoint.product_domain_char = f'[("id", "!=", {self.product.id})]'
+        candidate_products = orderpoint._get_candidate_products()
+        self.assertNotIn(self.product, candidate_products)
+
     def test_auto_replenishment(self):
         job_func = self.env["stock.location.orderpoint"].run_replenishment
         move_qty = 12
@@ -216,6 +227,40 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
             replenish_move_new = self._get_replenishment_move(orderpoint)
             self.assertEqual(replenish_move, replenish_move_new)
             self._assert_replenishment_move(replenish_move, move_qty * 2, orderpoint)
+
+    def test_auto_replenishment_with_product_domain(self):
+        orderpoint, location_src = self._create_orderpoint_complete(
+            "Stock2", trigger="auto"
+        )
+        orderpoint.product_domain_char = f'[("id", "!=", {self.product.id})]'
+        job_func = orderpoint.run_replenishment
+        with trap_jobs() as trap:
+            move = self._create_outgoing_move(12)
+            trap.assert_jobs_count(0, only=job_func)
+
+        # Create an incoming move to have available quantity, but no
+        # replenishment should be triggered because of the product domain
+        with trap_jobs() as trap:
+            move = self._create_incoming_move(12, location_src)
+            trap.assert_jobs_count(0, only=job_func)
+
+        # If I remove the product domain, the replenishment should be triggered
+        orderpoint.product_domain_char = "[]"
+        with trap_jobs() as trap:
+            move = self._create_incoming_move(1, location_src)
+            trap.assert_jobs_count(1, only=job_func)
+            trap.assert_enqueued_job(
+                orderpoint.run_replenishment,
+                args=(move.product_id,),
+                kwargs={},
+                properties=dict(
+                    identity_key=identity_exact,
+                ),
+            )
+            self.product.invalidate_recordset()
+            trap.perform_enqueued_jobs()
+            replenish_move = self._get_replenishment_move(orderpoint)
+            self._assert_replenishment_move(replenish_move, 12, orderpoint)
 
     def test_auto_replenishment_channel(self):
         """

--- a/stock_location_orderpoint/tests/test_location_orderpoint.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint.py
@@ -1,5 +1,6 @@
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import datetime
 from contextlib import contextmanager
 from unittest.mock import patch
 
@@ -124,6 +125,27 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
             trap.perform_enqueued_jobs()
         replenish_move = self._get_replenishment_move(orderpoint)
         self._assert_replenishment_move(replenish_move, 12, orderpoint)
+
+    def test_replenishment_horizon(self):
+        orderpoint, location_src = self._create_orderpoint_complete(
+            "Stock2", trigger="manual", proc_run_async=True
+        )
+        horizon = orderpoint.replenish_horizon
+        self._set_qty_in_location(self.product, location_src, 12)
+        self._create_outgoing_move(
+            12, date=fields.Datetime.now() + datetime.timedelta(days=horizon + 1)
+        )
+        with trap_jobs() as trap:
+            self._run_replenishment(orderpoint)
+            trap.assert_jobs_count(
+                0, only=self.env["stock.location.orderpoint"]._fulfill_procurement
+            )
+        orderpoint.replenish_horizon = horizon + 1
+        with trap_jobs() as trap:
+            self._run_replenishment(orderpoint)
+            trap.assert_jobs_count(
+                1, only=self.env["stock.location.orderpoint"]._fulfill_procurement
+            )
 
     def test_auto_replenishment(self):
         job_func = self.env["stock.location.orderpoint"].run_replenishment

--- a/stock_location_orderpoint/tests/test_location_orderpoint.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint.py
@@ -330,17 +330,18 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
         Create a stock move that should not create a replenishment:
           - A move from a new stock location 'WH/Stock 2' to Scrap
         """
-        job_func = self.env["stock.location.orderpoint"].run_auto_replenishment
+        orderpoint, _ = self._create_orderpoint_complete("Stock2", trigger="auto")
+        job_func = orderpoint.run_replenishment
+        new_location = self.env["stock.location"].create(
+            {
+                "name": "Other Stock",
+                "location_id": self.location_dest.location_id.id,
+            }
+        )
+        self.location_dest = new_location
+        self._create_quants(self.product, self.location_dest, 10.0)
+
         with trap_jobs() as trap:
-            new_location = self.env["stock.location"].create(
-                {
-                    "name": "Other Stock",
-                    "location_id": self.location_dest.location_id.id,
-                }
-            )
-            _, _ = self._create_orderpoint_complete("Stock2", trigger="auto")
-            self.location_dest = new_location
-            self._create_quants(self.product, self.location_dest, 10.0)
             move = self._create_scrap_move(10.0, self.location_dest)
             trap.assert_jobs_count(0, only=job_func)
             trap.perform_enqueued_jobs()

--- a/stock_location_orderpoint/tests/test_location_orderpoint.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint.py
@@ -19,10 +19,10 @@ from .common import TestLocationOrderpointCommon
 class TestLocationOrderpoint(TestLocationOrderpointCommon):
     def test_manual_replenishment(self):
         orderpoint, location_src = self._create_orderpoint_complete(
-            "Stock2", trigger="manual"
+            "Stock2", trigger="manual", proc_run_async=False
         )
         orderpoint2, location_src2 = self._create_orderpoint_complete(
-            "Stock2.2", trigger="manual"
+            "Stock2.2", trigger="manual", proc_run_async=False
         )
 
         self.assertEqual(orderpoint.location_src_id, location_src)
@@ -79,7 +79,7 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
     def test_cron_replenishment(self):
         cron = self.env.ref("stock_location_orderpoint.ir_cron_location_replenishment")
         orderpoint, location_src = self._create_orderpoint_complete(
-            "Stock2", trigger="cron"
+            "Stock2", trigger="cron", proc_run_async=False
         )
         # at this point the orderpoint has no last_cron_execution
         self.assertFalse(orderpoint.last_cron_execution)
@@ -109,12 +109,28 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
         self._assert_replenishment_move(replenish_move, 12, orderpoint)
         self.assertEqual(orderpoint.last_cron_execution, day_after_tomorrow)
 
+    def test_replenishment_delay_procurement_run(self):
+        orderpoint, location_src = self._create_orderpoint_complete(
+            "Stock2", trigger="manual", proc_run_async=True
+        )
+        self._create_outgoing_move(12)
+        self._set_qty_in_location(self.product, location_src, 12)
+        with trap_jobs() as trap:
+            self._run_replenishment(orderpoint)
+            trap.assert_jobs_count(
+                1, only=self.env["stock.location.orderpoint"]._fulfill_procurement
+            )
+            self.product.invalidate_recordset()
+            trap.perform_enqueued_jobs()
+        replenish_move = self._get_replenishment_move(orderpoint)
+        self._assert_replenishment_move(replenish_move, 12, orderpoint)
+
     def test_auto_replenishment(self):
-        job_func = self.env["stock.location.orderpoint"].run_auto_replenishment
+        job_func = self.env["stock.location.orderpoint"].run_replenishment
         move_qty = 12
         with trap_jobs() as trap:
             move = self._create_outgoing_move(move_qty)
-            trap.assert_jobs_count(0, only=job_func)
+            trap.assert_jobs_count(0)
             trap.perform_enqueued_jobs()
             replenish_move = self.env["stock.move"].search(
                 [
@@ -127,12 +143,13 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
         orderpoint, location_src = self._create_orderpoint_complete(
             "Stock2", trigger="auto"
         )
+        job_func = orderpoint.run_replenishment
         with trap_jobs() as trap:
             move = self._create_outgoing_move(move_qty)
             trap.assert_jobs_count(1, only=job_func)
             trap.assert_enqueued_job(
-                orderpoint.browse([]).run_auto_replenishment,
-                args=(move.product_id, move.location_id, "location_id"),
+                orderpoint.run_replenishment,
+                args=(move.product_id,),
                 kwargs={},
                 properties=dict(
                     identity_key=identity_exact,
@@ -147,8 +164,8 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
             move = self._create_incoming_move(move_qty, location_src)
             trap.assert_jobs_count(1, only=job_func)
             trap.assert_enqueued_job(
-                orderpoint.browse([]).run_auto_replenishment,
-                args=(move.product_id, move.location_dest_id, "location_src_id"),
+                orderpoint.run_replenishment,
+                args=(move.product_id,),
                 kwargs={},
                 properties=dict(
                     identity_key=identity_exact,
@@ -165,8 +182,8 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
             move = self._create_outgoing_move(move_qty)
             trap.assert_jobs_count(1, only=job_func)
             trap.assert_enqueued_job(
-                orderpoint.browse([]).run_auto_replenishment,
-                args=(move.product_id, move.location_id, "location_id"),
+                orderpoint.run_replenishment,
+                args=(move.product_id,),
                 kwargs={},
                 properties=dict(
                     identity_key=identity_exact,
@@ -183,19 +200,19 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
         Check that the channel for enqueud job is
         root.stock_location_orderpoint_auto_replenishment
         """
-        job_func = self.env["stock.location.orderpoint"].run_auto_replenishment
         move_qty = 12
 
         orderpoint, location_src = self._create_orderpoint_complete(
             "Stock2",
             trigger="auto",
         )
+        job_func = orderpoint.run_replenishment
         with trap_jobs() as trap:
             move = self._create_outgoing_move(move_qty)
             trap.assert_jobs_count(1, only=job_func)
             trap.assert_enqueued_job(
-                orderpoint.browse([]).run_auto_replenishment,
-                args=(move.product_id, move.location_id, "location_id"),
+                job_func,
+                args=(move.product_id,),
                 kwargs={},
                 properties=dict(
                     identity_key=identity_exact,
@@ -210,8 +227,8 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
             move = self._create_incoming_move(move_qty, location_src)
             trap.assert_jobs_count(1, only=job_func)
             trap.assert_enqueued_job(
-                orderpoint.browse([]).run_auto_replenishment,
-                args=(move.product_id, move.location_dest_id, "location_src_id"),
+                job_func,
+                args=(move.product_id,),
                 kwargs={},
                 properties=dict(
                     identity_key=identity_exact,
@@ -219,7 +236,9 @@ class TestLocationOrderpoint(TestLocationOrderpointCommon):
             )
             job = trap.enqueued_jobs[0]
             self.assertEqual(
-                job.channel, "root.stock_location_orderpoint_auto_replenishment"
+                job.channel,
+                "root.stock_location_orderpoint_replenishment."
+                "stock_location_orderpoint_auto_replenishment",
             )
 
     def test_auto_no_replenishment(self):

--- a/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
@@ -1,6 +1,7 @@
 # Copyright 2023 ACSONE SA/NV (http://www.acsone.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import datetime
 
 from odoo.addons.queue_job.job import identity_exact
 from odoo.addons.queue_job.tests.common import trap_jobs
@@ -21,20 +22,24 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
 
         Make the orderpoint an automatic orderpoint with 'urgent' priority
 
-        Change the existing outgoing move quantity (with lower need)
+        Refill available quantity in reserve location
 
-        Create an outgoing move with the difference quantity (no move should be created)
+        Create an outgoing move (no move should be created)
 
-        Check that the replenishment move priority has changed to 'urgent'.
+        Launch the replenishment
+
+        Check that the replenishment move has been  updated to 'urgent'
+        and the qty to replenish is updated according to the new
+        outgoing move qty.
         """
-        job_func = self.env["stock.location.orderpoint"].run_auto_replenishment
         move_qty = 12
 
         manual_orderpoint, location_src = self._create_orderpoint_complete(
             "Stock2",
             trigger="manual",
+            proc_run_async=False,
         )
-        out_move = self._create_outgoing_move(move_qty)
+        self._create_outgoing_move(move_qty)
         self._create_incoming_move(move_qty, location_src)
         manual_orderpoint.run_replenishment()
         replenish_move_manual = self._get_replenishment_move(manual_orderpoint)
@@ -43,35 +48,30 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
         self.assertEqual(12.0, replenish_move_manual.product_uom_qty)
         self.assertEqual("0", replenish_move_manual.priority)
 
-        # Change the outgoing quantity
-        out_move.product_uom_qty = 6.0
-
-        self.assertEqual(6.0, out_move.product_uom_qty)
-
         manual_orderpoint.update(
             {
                 "trigger": "auto",
                 "priority": "1",
             }
         )
-
+        job_func = manual_orderpoint.run_replenishment
+        self._set_qty_in_location(self.product, location_src, 20)
         with trap_jobs() as trap:
             out_move_2 = self._create_outgoing_move(2.0)
             trap.assert_jobs_count(1, only=job_func)
             trap.assert_enqueued_job(
-                manual_orderpoint.browse([]).run_auto_replenishment,
-                args=(out_move_2.product_id, out_move_2.location_id, "location_id"),
+                job_func,
+                args=(out_move_2.product_id,),
                 kwargs={},
                 properties=dict(
                     identity_key=identity_exact,
                 ),
             )
             trap.perform_enqueued_jobs()
-
         replenish_move = self._get_replenishment_move(manual_orderpoint)
         self.assertEqual(replenish_move, replenish_move_manual)
 
-        self.assertEqual(replenish_move.product_uom_qty, 12.0)
+        self.assertEqual(replenish_move.product_uom_qty, move_qty + 2.0)
 
         # Check priority has been changed
         self.assertEqual("1", replenish_move.priority)
@@ -88,11 +88,17 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
 
         Update orderpoint priority to 'urgent'
 
-        Change the existing outgoing move quantity (with lower need)
+        Refill available quantity in reserve location
 
-        Create an outgoing move with the difference quantity (no move should be created)
+        Create an outgoing move (no move should be created)
 
-        Check that both replenishment moves priority has changed to 'urgent'.
+        Launch the replenishment
+
+        Check that the replenishment move for the product 1 has been
+        updated to 'urgent' and the one for product 2 is still 'normal'.
+        The qty to replenish for product 1 should be updated according
+        to the new outgoing move qty.
+
         """
         product_1 = self.product
         product_2 = self.env["product.product"].create(
@@ -101,13 +107,14 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
                 "type": "product",
             }
         )
-        move_qty = 12
+        move_qty = 10
 
         orderpoint, location_src = self._create_orderpoint_complete(
             "Stock2",
             trigger="manual",
+            proc_run_async=False,
         )
-        out_move = self._create_outgoing_move(move_qty)
+        self._create_outgoing_move(move_qty)
         self._create_incoming_move(move_qty, location_src)
 
         self.product = product_2
@@ -127,13 +134,18 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
         self.assertTrue(replenish_move_manual_2)
 
         # Change the outgoing quantity
-        out_move.product_uom_qty = 6.0
-        self.assertEqual(6.0, out_move.product_uom_qty)
 
         orderpoint.priority = "1"
 
         self.product = product_1
-        self._create_outgoing_move(2.0)
+        self._set_qty_in_location(product_1, location_src, 20)
+        # we use a date in the past to check that the resulting
+        # replenishment move will be planned at the right date (i.e. the one of the
+        #  new outgoing move) and the picking scheduled date is updated accordingly
+        move_date = datetime.datetime(2023, 1, 1)
+        self._create_outgoing_move(
+            2.0, date=move_date
+        )  # make sure the move is taken into account in replenishment
 
         orderpoint.run_replenishment()
 
@@ -141,11 +153,13 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
         replenish_move_2 = self._get_replenishment_move(orderpoint, product=product_2)
 
         self.assertEqual(replenish_move, replenish_move_manual_1)
-        self.assertEqual(replenish_move.product_uom_qty, 12.0)
+        self.assertEqual(replenish_move.product_uom_qty, move_qty + 2.0)
+        self.assertEqual(replenish_move.date, move_date)
+        self.assertEqual(replenish_move.picking_id.scheduled_date, move_date)
 
         # Check priority has been changed (for both moves)
         self.assertEqual("1", replenish_move.priority)
-        self.assertEqual("1", replenish_move_2.priority)
+        self.assertEqual("0", replenish_move_2.priority)
 
     def test_mixed_replenishment_priority_bis(self):
         """
@@ -192,6 +206,7 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
         orderpoint, location_src = self._create_orderpoint_complete(
             "Stock2",
             trigger="manual",
+            proc_run_async=False,
         )
         self._create_outgoing_move(move_qty)
         self._create_incoming_move(move_qty, location_src)
@@ -200,7 +215,8 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
 
         orderpoint_2 = orderpoint.copy({"priority": "1"})
         self.product = product_2
-        self._create_outgoing_move(move_qty, product=product_2)
+        move_date = datetime.datetime(2023, 1, 1)
+        self._create_outgoing_move(move_qty, product=product_2, date=move_date)
         self._create_incoming_move(move_qty, location_src, product=product_2)
         orderpoint_2.run_replenishment()
         replenish_move_2 = self._get_replenishment_move(orderpoint_2, product=product_2)
@@ -210,8 +226,10 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
 
         self.assertEqual("0", replenish_move_1.priority)
         self.assertEqual("1", replenish_move_2.priority)
+        self.assertEqual(move_date, replenish_move_2.date)
         self.assertEqual(replenish_move_1.picking_id, replenish_move_2.picking_id)
         self.assertEqual("1", replenish_move_1.picking_id.priority)
+        self.assertEqual(move_date, replenish_move_2.picking_id.scheduled_date)
 
     def test_merged_replenishment_move_priority(self):
         """
@@ -249,6 +267,7 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
         ) = self._create_orderpoint_complete(
             "Reserve",
             trigger="manual",
+            proc_run_async=False,
         )
         manual_orderpoint_2 = manual_orderpoint_1.copy({"priority": "1"})
 

--- a/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
@@ -147,6 +147,72 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
         self.assertEqual("1", replenish_move.priority)
         self.assertEqual("1", replenish_move_2.priority)
 
+    def test_mixed_replenishment_priority_bis(self):
+        """
+        Create a manual orderpoint with 'normal' priority
+
+        Create moves that will generate replenishment (outgoing + quantity on Reserve).
+
+        Run the manual orderpoint
+
+        Check the move is created
+
+        Create a second orderpoint with 'urgent' priority
+
+        Create moves that will generate replenishment (outgoing + quantity on Reserve).
+
+        Run the second orderpoint for an other product
+
+        Check the move is created
+
+        Each moves must:
+        - be linked to the correct orderpoint
+        - have the correct priority
+
+        The picking must have the highest priority between the 2 moves (i.e. 'urgent')
+
+        """
+        # we drop the unique constraint here because ideally we want to create orderpoints
+        # for the same location with different priority
+        self.env.cr.execute(
+            """
+            ALTER TABLE stock_location_orderpoint
+            DROP CONSTRAINT stock_location_orderpoint_location_route_unique;
+            """
+        )
+        product_1 = self.product
+        product_2 = self.env["product.product"].create(
+            {
+                "name": "Product 2",
+                "type": "product",
+            }
+        )
+        move_qty = 12
+
+        orderpoint, location_src = self._create_orderpoint_complete(
+            "Stock2",
+            trigger="manual",
+        )
+        self._create_outgoing_move(move_qty)
+        self._create_incoming_move(move_qty, location_src)
+        orderpoint.run_replenishment()
+        replenish_move_1 = self._get_replenishment_move(orderpoint, product=product_1)
+
+        orderpoint_2 = orderpoint.copy({"priority": "1"})
+        self.product = product_2
+        self._create_outgoing_move(move_qty, product=product_2)
+        self._create_incoming_move(move_qty, location_src, product=product_2)
+        orderpoint_2.run_replenishment()
+        replenish_move_2 = self._get_replenishment_move(orderpoint_2, product=product_2)
+
+        self.assertTrue(replenish_move_1)
+        self.assertTrue(replenish_move_2)
+
+        self.assertEqual("0", replenish_move_1.priority)
+        self.assertEqual("1", replenish_move_2.priority)
+        self.assertEqual(replenish_move_1.picking_id, replenish_move_2.picking_id)
+        self.assertEqual("1", replenish_move_1.picking_id.priority)
+
     def test_merged_replenishment_move_priority(self):
         """
         Test that merged replenishment moves coming from different orderpoints

--- a/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
@@ -1,0 +1,213 @@
+# Copyright 2023 ACSONE SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo.addons.queue_job.job import identity_exact
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+from .common import TestLocationOrderpointCommon
+
+
+class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
+    def test_mixed_replenishment_priority(self):
+        """
+        Create a manual orderpoint with 'normal' priority
+
+        Create moves that will generate replenishment (ougoing + quantity on Reserve).
+
+        Run the manual orderpoint
+
+        Check the move is created
+
+        Make the orderpoint an automatic orderpoint with 'urgent' priority
+
+        Change the existing outgoing move quantity (with lower need)
+
+        Create an outgoing move with the difference quantity (no move should be created)
+
+        Check that the replenishment move priority has changed to 'urgent'.
+        """
+        job_func = self.env["stock.location.orderpoint"].run_auto_replenishment
+        move_qty = 12
+
+        manual_orderpoint, location_src = self._create_orderpoint_complete(
+            "Stock2",
+            trigger="manual",
+        )
+        out_move = self._create_outgoing_move(move_qty)
+        self._create_incoming_move(move_qty, location_src)
+        manual_orderpoint.run_replenishment()
+        replenish_move_manual = self._get_replenishment_move(manual_orderpoint)
+
+        self.assertTrue(replenish_move_manual)
+        self.assertEqual(12.0, replenish_move_manual.product_uom_qty)
+        self.assertEqual("0", replenish_move_manual.priority)
+
+        # Change the outgoing quantity
+        out_move.product_uom_qty = 6.0
+
+        self.assertEqual(6.0, out_move.product_uom_qty)
+
+        manual_orderpoint.update(
+            {
+                "trigger": "auto",
+                "priority": "1",
+            }
+        )
+
+        with trap_jobs() as trap:
+            out_move_2 = self._create_outgoing_move(2.0)
+            trap.assert_jobs_count(1, only=job_func)
+            trap.assert_enqueued_job(
+                manual_orderpoint.browse([]).run_auto_replenishment,
+                args=(out_move_2.product_id, out_move_2.location_id, "location_id"),
+                kwargs={},
+                properties=dict(
+                    identity_key=identity_exact,
+                ),
+            )
+            trap.perform_enqueued_jobs()
+
+        replenish_move = self._get_replenishment_move(manual_orderpoint)
+        self.assertEqual(replenish_move, replenish_move_manual)
+
+        self.assertEqual(replenish_move.product_uom_qty, 12.0)
+
+        # Check priority has been changed
+        self.assertEqual("1", replenish_move.priority)
+
+    def test_mixed_replenishment_priority_two_products(self):
+        """
+        Create a manual orderpoint with 'normal' priority
+
+        Create moves that will generate replenishment (outgoing + quantity on Reserve).
+
+        Run the manual orderpoint
+
+        Check the move is created
+
+        Update orderpoint priority to 'urgent'
+
+        Change the existing outgoing move quantity (with lower need)
+
+        Create an outgoing move with the difference quantity (no move should be created)
+
+        Check that both replenishment moves priority has changed to 'urgent'.
+        """
+        product_1 = self.product
+        product_2 = self.env["product.product"].create(
+            {
+                "name": "Product 2",
+                "type": "product",
+            }
+        )
+        move_qty = 12
+
+        orderpoint, location_src = self._create_orderpoint_complete(
+            "Stock2",
+            trigger="manual",
+        )
+        out_move = self._create_outgoing_move(move_qty)
+        self._create_incoming_move(move_qty, location_src)
+
+        self.product = product_2
+        self._create_outgoing_move(move_qty, product=product_2)
+        self._create_incoming_move(move_qty, location_src, product=product_2)
+
+        orderpoint.run_replenishment()
+
+        replenish_move_manual_1 = self._get_replenishment_move(
+            orderpoint, product=product_1
+        )
+        replenish_move_manual_2 = self._get_replenishment_move(
+            orderpoint, product=product_2
+        )
+
+        self.assertTrue(replenish_move_manual_1)
+        self.assertTrue(replenish_move_manual_2)
+
+        # Change the outgoing quantity
+        out_move.product_uom_qty = 6.0
+        self.assertEqual(6.0, out_move.product_uom_qty)
+
+        orderpoint.priority = "1"
+
+        self.product = product_1
+        self._create_outgoing_move(2.0)
+
+        orderpoint.run_replenishment()
+
+        replenish_move = self._get_replenishment_move(orderpoint, product=product_1)
+        replenish_move_2 = self._get_replenishment_move(orderpoint, product=product_2)
+
+        self.assertEqual(replenish_move, replenish_move_manual_1)
+        self.assertEqual(replenish_move.product_uom_qty, 12.0)
+
+        # Check priority has been changed (for both moves)
+        self.assertEqual("1", replenish_move.priority)
+        self.assertEqual("1", replenish_move_2.priority)
+
+    def test_merged_replenishment_move_priority(self):
+        """
+        Test that merged replenishment moves coming from different orderpoints
+        inherit the highest priority orderpoint.
+
+        Setup:
+            - Create a manual orderpoint with priotity 0
+            - Create a manual orderpoint with priotity 1 (same location as 1st one)
+            - Create a shortage on orderpoints location
+            - trigger orderpoint 0 for replenishment
+            - Create a shortage on location again
+            - Trigger orderpoint 1 for replenishment
+
+        Expected result:
+            - The resulting merged repl move to account for both shortage set on
+              location should be linked to orderpoint '1' (and have a priority of '1')
+        """
+
+        # ↓ we drop the unique constraint here because ideally we want to create orderpoints
+        # that have exactly the same characteristics except for the replenish_method (in order
+        # to make sure the moves get merged)
+        # However, we only have 1 replenish_method available and we do not want to
+        # add another dependency (e.g. avg_daily_sale)
+        self.env.cr.execute(
+            """
+            ALTER TABLE stock_location_orderpoint
+            DROP CONSTRAINT stock_location_orderpoint_location_route_unique;
+            """
+        )
+
+        (
+            manual_orderpoint_1,
+            orderpoints_src_location,
+        ) = self._create_orderpoint_complete(
+            "Reserve",
+            trigger="manual",
+        )
+        manual_orderpoint_2 = manual_orderpoint_1.copy({"priority": "1"})
+
+        self.assertEqual(
+            manual_orderpoint_1.location_id, manual_orderpoint_2.location_id
+        )
+        self.assertEqual(
+            manual_orderpoint_1.location_src_id, manual_orderpoint_2.location_src_id
+        )
+        self.assertEqual(manual_orderpoint_1.route_id, manual_orderpoint_2.route_id)
+
+        # Make some stock in the orderpoints sources
+        self._create_incoming_move(100, orderpoints_src_location)
+
+        # create a move that introduces a shortage on orderpoints location
+        self._create_outgoing_move(20)
+
+        # trigger creation of first orderpoint repl move
+        manual_orderpoint_1.run_replenishment()
+        repl_move = self._get_replenishment_move(manual_orderpoint_1)
+        self._assert_replenishment_move(repl_move, 20, manual_orderpoint_1)
+
+        # introduce shortage again on orderpoints location
+        self._create_outgoing_move(20)
+
+        # trigger creation of first orderpoint repl move
+        manual_orderpoint_2.run_replenishment()
+        self._assert_replenishment_move(repl_move, 40, manual_orderpoint_2)

--- a/stock_location_orderpoint/views/stock_location_orderpoint_views.xml
+++ b/stock_location_orderpoint/views/stock_location_orderpoint_views.xml
@@ -64,20 +64,38 @@
                 <group>
                     <field name="location_id" />
                     <field name="location_src_id" />
+
                     <field name="route_id" />
                     <field name="group_id" />
                     <field name="priority" />
                     <field name="replenish_limit_to_free_qty" />
                     <field name="replenish_horizon" />
                 </group>
-                <group name="exclude_locations" string="Exclude Locations">
-                    <field name="stock_excluded_location_ids" widget="many2many_tags" />
-                    <field
-                            name="stock_excluded_location_domain_char"
-                            widget="domain"
-                            options="{'model': 'stock.quant'}"
-                        />
-                </group>
+                <notebook>
+                    <page name="filter_products" string="Filter products">
+                        <group>
+                        <field
+                                    name="product_domain_char"
+                                    widget="domain"
+                                    options="{'model': 'product.product'}"
+                                />
+                        </group>
+                    </page>
+                    <page name="filter_locations" string="Filter locations">
+                        <group name="exclude_locations">
+                            <field
+                                    name="stock_excluded_location_ids"
+                                    widget="many2many_tags"
+                                />
+                            <field
+                                    name="stock_excluded_location_domain_char"
+                                    widget="domain"
+                                    options="{'model': 'stock.quant'}"
+                                />
+                        </group>
+                    </page>
+                </notebook>
+
             </sheet>
         </form>
     </field>

--- a/stock_location_orderpoint/views/stock_location_orderpoint_views.xml
+++ b/stock_location_orderpoint/views/stock_location_orderpoint_views.xml
@@ -68,6 +68,7 @@
                     <field name="group_id" />
                     <field name="priority" />
                     <field name="replenish_limit_to_free_qty" />
+                    <field name="replenish_horizon" />
                 </group>
                 <group name="exclude_locations" string="Exclude Locations">
                     <field name="stock_excluded_location_ids" widget="many2many_tags" />

--- a/stock_location_orderpoint/views/stock_location_orderpoint_views.xml
+++ b/stock_location_orderpoint/views/stock_location_orderpoint_views.xml
@@ -55,6 +55,10 @@
                     <field name="sequence" />
                     <field name="trigger" />
                     <field name="replenish_method" />
+                    <field
+                            name="proc_run_async"
+                            attrs="{'invisible': [('trigger', '=', 'auto')]}"
+                        />
                     <field name="company_id" invisible="1" />
                 </group>
                 <group>
@@ -63,6 +67,7 @@
                     <field name="route_id" />
                     <field name="group_id" />
                     <field name="priority" />
+                    <field name="replenish_limit_to_free_qty" />
                 </group>
                 <group name="exclude_locations" string="Exclude Locations">
                     <field name="stock_excluded_location_ids" widget="many2many_tags" />

--- a/stock_location_orderpoint_cleanup/tests/test_location_orderpoint_cleanup.py
+++ b/stock_location_orderpoint_cleanup/tests/test_location_orderpoint_cleanup.py
@@ -57,7 +57,7 @@ class TestLocationOrderpointCleanup(TestLocationOrderpointCommon):
     def test_orderpoint(self):
         """ """
         orderpoint, location_src = self._create_orderpoint_complete(
-            "Reserve", trigger="manual"
+            "Reserve", trigger="manual", proc_run_async=False
         )
 
         # Create quantities on Reserve location
@@ -100,7 +100,7 @@ class TestLocationOrderpointCleanup(TestLocationOrderpointCommon):
     def test_orderpoint_wizard(self):
         """ """
         orderpoint, location_src = self._create_orderpoint_complete(
-            "Reserve", trigger="manual"
+            "Reserve", trigger="manual", proc_run_async=False
         )
 
         # Create quantities on Reserve location
@@ -150,7 +150,7 @@ class TestLocationOrderpointCleanup(TestLocationOrderpointCommon):
     def test_orderpoint_run_after(self):
         """ """
         orderpoint, location_src = self._create_orderpoint_complete(
-            "Reserve", trigger="manual"
+            "Reserve", trigger="manual", proc_run_async=False
         )
 
         # Create quantities on Reserve location
@@ -198,7 +198,7 @@ class TestLocationOrderpointCleanup(TestLocationOrderpointCommon):
     def test_orderpoint_run_after_partial(self):
         """ """
         orderpoint, location_src = self._create_orderpoint_complete(
-            "Reserve", trigger="manual"
+            "Reserve", trigger="manual", proc_run_async=False
         )
 
         # Create quantities on Reserve location
@@ -247,7 +247,7 @@ class TestLocationOrderpointCleanup(TestLocationOrderpointCommon):
     def test_orderpoint_cron(self):
         """ """
         orderpoint, location_src = self._create_orderpoint_complete(
-            "Reserve", trigger="manual"
+            "Reserve", trigger="manual", proc_run_async=False
         )
 
         # Create quantities on Reserve location
@@ -297,7 +297,7 @@ class TestLocationOrderpointCleanup(TestLocationOrderpointCommon):
     def test_orderpoint_cron_replenish(self):
         """ """
         orderpoint, location_src = self._create_orderpoint_complete(
-            "Reserve", trigger="manual"
+            "Reserve", trigger="manual", proc_run_async=False
         )
 
         # Create quantities on Reserve location


### PR DESCRIPTION
Clean separation of concerns between the computation of the demand and the execution of the procurement, allowing to implement different strategies to compute the demand and to prioritize the replenishment moves.

Defines a new model stock.location.orderpoint.strategy that is meant to be inherited to implement different strategies to compute the demand. The default strategy is implemented in the stock_location_orderpoint_strategy_fill_up model, and implements the "fill up" strategy, which consists in replenishing the stock until the maximum quantity defined on the orderpoint.

We also put in place an explicit orchestration of the replenishment process in the stock.location.orderpoint model, which splits the process in explicit steps allowing to easily hook into the process and modify the behavior of the module. The steps are:
- select the products to replenish
- compute the demand for each product
- compute available quantity in the location for each product
- compute the procurement quantity for each product
- execute the procurement for products with positive procurement quantity
- post-process the created replenishment moves (e.g. to set their priority according to the strategy)
 
Some of these steps default implementation is delegated to the strategy model, allowing to easily change the behavior of the module by implementing a new strategy and/or overriding specific steps of the process.

fixes #84

* [ ] includes #82 
* [ ] #4 has been adapted