### PR TITLE
[FIX] stock_orderpoint_origin: Empty procurement

### DIFF
--- a/stock_orderpoint_origin/models/procurement_group.py
+++ b/stock_orderpoint_origin/models/procurement_group.py
@@ -33,6 +33,9 @@ class ProcurementGroup(models.Model):
                     x.procurement_group_id if x._name != "stock.picking" else x.group_id
                     for x in source_docs
                 ]
+                source_groups = self.env["procurement.group"].browse(
+                    proc.id for proc in source_groups if proc
+                )
                 source_names = ", ".join([x.name for x in source_docs])
                 new_origin = "%s (from %s)" % (source_names, procurement.origin)
                 new_procurement = procurement._replace(origin=new_origin)

--- a/stock_orderpoint_origin/tests/test_stock_orderpoint.py
+++ b/stock_orderpoint_origin/tests/test_stock_orderpoint.py
@@ -49,3 +49,37 @@ class TestOrderpointPurchaseLink(common.TransactionCase):
         self.assertIn(purchase_order.order_line.source_group_ids.sale_id, sale_orders)
         so_name = sale_orders.mapped("name")[0]
         self.assertIn(so_name, origin)
+
+    def test_picking_empty_procurement(self):
+        """If a picking has no procurement, the source groups are listed."""
+        # Arrange
+        picking_form = common.Form(self.env["stock.picking"])
+        picking_form.picking_type_id = self.env.ref("stock.picking_type_out")
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = self.product
+            move.product_uom_qty = 1
+        picking = picking_form.save()
+        picking.action_confirm()
+        # pre-condition
+        self.assertFalse(picking.group_id)
+
+        # Act
+        op = self.env["stock.warehouse.orderpoint"].create(
+            {
+                "name": self.product.name,
+                "location_id": self.stock_location_id,
+                "product_id": self.product.id,
+                "product_min_qty": 1,
+                "product_max_qty": 8,
+                "qty_to_order": 3,
+                "trigger": "manual",
+            }
+        )
+        op.action_replenish()
+
+        # Assert
+        purchase_order_line = self.env["purchase.order.line"].search(
+            [("product_id", "=", self.product.id)], order="id desc", limit=1
+        )
+        self.assertTrue(purchase_order_line)
+        self.assertEqual(len(purchase_order_line.source_group_ids), 1)


### PR DESCRIPTION
If there is no procurement in a source document, the following is raised:
```
ERROR devel odoo.sql_db: bad query: INSERT INTO procurement_group_purchase_order_line_rel (purchase_order_line_id, procurement_group_id) VALUES (24, 5), (24, false) ON CONFLICT DO NOTHING
ERROR: column "procurement_group_id" is of type integer but expression is of type boolean
LINE 1: ...ne_id, procurement_group_id) VALUES (24, 5), (24, false) ON ...
                                                             ^
HINT:  You will need to rewrite or cast the expression.

ERROR devel odoo.addons.stock_orderpoint_origin.tests.test_stock_orderpoint: ERROR: TestOrderpointPurchaseLink.test_picking_empty_procurement
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/stock_orderpoint_origin/tests/test_stock_orderpoint.py", line 78, in test_picking_empty_procurement
    op.action_replenish()
  File "/opt/odoo/auto/addons/stock/models/stock_orderpoint.py", line 229, in action_replenish
    self._procure_orderpoint_confirm(company_id=self.env.company)
  File "/opt/odoo/auto/addons/stock/models/stock_orderpoint.py", line 568, in _procure_orderpoint_confirm
    self.env['procurement.group'].with_context(from_orderpoint=True).run(procurements, raise_user_error=raise_user_error)
  File "/opt/odoo/auto/addons/stock_orderpoint_origin/models/procurement_group.py", line 43, in run
    return super().run(new_procurements, raise_user_error)
  File "/opt/odoo/auto/addons/purchase_stock/models/stock.py", line 247, in run
    return super().run(procurements, raise_user_error=raise_user_error)
  File "/opt/odoo/auto/addons/stock/models/stock_rule.py", line 479, in run
    getattr(self.env['stock.rule'], '_run_%s' % action)(procurements)
  File "/opt/odoo/auto/addons/purchase_stock/models/stock_rule.py", line 157, in _run_buy
    self.env['purchase.order.line'].sudo().create(po_line_values)
  File "<decorator-gen-216>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/auto/addons/purchase_stock/models/purchase.py", line 392, in create
    lines = super(PurchaseOrderLine, self).create(vals_list)
  File "<decorator-gen-213>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/auto/addons/purchase/models/purchase.py", line 1130, in create
    lines = super().create(vals_list)
  File "<decorator-gen-160>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/auto/addons/analytic/models/analytic_mixin.py", line 89, in create
    return super().create(vals_list)
  File "<decorator-gen-68>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_fields.py", line 670, in create
    recs = super().create(vals_list)
  File "<decorator-gen-15>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4019, in create
    records = self._create(data_list)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4256, in _create
    field.create([
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 4287, in create
    self.write_batch(record_values, True)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 4313, in write_batch
    return self.write_real(records_commands_list, create)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 4910, in write_real
    cr.execute(query, pairs)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 324, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.DatatypeMismatch: column "procurement_group_id" is of type integer but expression is of type boolean LINE 1: ...ne_id, procurement_group_id) VALUES (24, 5), (24, false) ON ...
                                                             ^
HINT:  You will need to rewrite or cast the expression.
```

I also change the `source_group_ids` value so that it's a recordset, like the other `*_ids` values in `procurement.values` (see for instance https://github.com/odoo/odoo/blob/6aca71c9522b3be5b221847e8b005f233d3ea872/addons/purchase_stock/models/stock.py#L246) because the error was actually triggered in https://github.com/OCA/stock-logistics-orderpoint/blob/eebb6d309c623dbd98271f0d7748c3d4f7cb09cf/stock_orderpoint_origin/models/purchase_order.py#L36-L38 when there are no procurements, `groups` is `[procurement.group()]`, so a `[(4, False)]` is added, and then the above error is triggered when converting that to a query.