### PR TITLE
[16.0][FIX] stock_location_orderpoint: reclaim moves from lower priority orderpoints 

### DIFF
--- a/stock_location_orderpoint/models/__init__.py
+++ b/stock_location_orderpoint/models/__init__.py
@@ -5,3 +5,4 @@ from . import stock_location
 from . import stock_location_orderpoint_strategy
 from . import stock_location_orderpoint_strategy_fill_up
 from . import stock_location_replenishment_computer
+from . import product_product

--- a/stock_location_orderpoint/models/product_product.py
+++ b/stock_location_orderpoint/models/product_product.py
@@ -1,0 +1,27 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+from odoo.osv import expression
+
+
+class ProductProduct(models.Model):
+
+    _inherit = "product.product"
+
+    def _get_domain_locations_new(self, location_ids):
+        (_q, domain_move_in_loc, _ol) = super()._get_domain_locations_new(location_ids)
+
+        if orderpoint_id := self.env.context.get("orderpoint_id"):
+            orderpoint = self.env["stock.location.orderpoint"].browse(orderpoint_id)
+
+            domain_move_in_loc = expression.AND(
+                [
+                    domain_move_in_loc,
+                    [
+                        ("location_orderpoint_id", "!=", orderpoint.id),
+                        ("location_orderpoint_id.priority", ">=", orderpoint.priority),
+                    ],
+                ]
+            )
+        return (_q, domain_move_in_loc, _ol)

--- a/stock_location_orderpoint/models/stock_location.py
+++ b/stock_location_orderpoint/models/stock_location.py
@@ -51,7 +51,9 @@ class StockLocation(models.Model):
         return action
 
     @api.model
-    @tools.ormcache_context("location_id", keys=("excluded_location_domain_cache_key",))
+    @tools.ormcache_context(
+        "location_id", keys=("excluded_location_domain_cache_key", "orderpoint_id")
+    )
     def _get_cached_stock_domains(self, location_id):
         return self.env["product.product"]._get_domain_locations_new(location_id)
 

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -432,6 +432,34 @@ class StockLocationOrderpoint(models.Model):
         self.ensure_one()
         return (self.priority, self.location_id.id, product_id)
 
+    def _reclaim_replenishing_moves_from_lower_priority_orderpoints(self):
+        """Reassign existing replenishing moves from lower-priority orderpoints to this one.
+
+        Ensures higher-priority orderpoints inherit existing moves and bump their priority
+        instead of being ignored by the procurement engine.
+        """
+        self.ensure_one()
+        consumed_products_ids = [
+            x["product_id"]
+            for x in self.env["stock.move"].search_read(
+                self._get_consuming_moves_domain(), ["product_id"], load=None
+            )
+        ]
+        replenishment_moves = self.env["stock.move"].search(
+            [
+                ("location_orderpoint_id", "not in", [False, self.id]),
+                ("location_dest_id", "=", self.location_id.id),
+                ("priority", "<", self.priority),
+                ("product_id", "in", consumed_products_ids),
+                ("state", "not in", ("cancel", "done", "draft")),
+            ]
+        )
+        for move in replenishment_moves:
+            move.location_orderpoint_id = self.id
+            move.origin += f"/{self.name}"
+            move.name = self.name
+        return replenishment_moves
+
     def _run_replenishment(self, products=None, processed=None, job_logs=None):
         """
         Internal pipeline:
@@ -454,12 +482,14 @@ class StockLocationOrderpoint(models.Model):
           are always atomic within a single transaction. The number of jobs
           is bounded by the number of products with actual demand.
         """
-        result = self.env["stock.move"]
+
         processed = processed or set()
         self.ensure_one()
         is_delayed = self._must_delay_fulfill_procurement()
-
         products = self._get_candidate_products(products)
+        replenishment_moves = (
+            self._reclaim_replenishing_moves_from_lower_priority_orderpoints()
+        )
 
         # Filter out products already handled by a higher-priority orderpoint
         # sharing the same location. Only meaningful in the async path.
@@ -476,7 +506,7 @@ class StockLocationOrderpoint(models.Model):
                         orderpoint=self.display_name,
                     )
                 )
-            return result
+            return replenishment_moves
 
         # Single call to the computer:
         #   demand_only=True  → returns {product_id: demand_qty}  (async path)
@@ -505,12 +535,12 @@ class StockLocationOrderpoint(models.Model):
                         orderpoint=self.display_name,
                     )
                 )
-            return result
+            return self._after_replenishment(replenishment_moves)
 
         if is_delayed:
             for product_id, demand_qty in procurement_data.items():
                 self._enqueue_fulfill_procurement(product_id, demand_qty).delay()
-            return result
+            return self._after_replenishment(replenishment_moves)
 
         if job_logs is not None:
             job_logs.append(
@@ -524,10 +554,10 @@ class StockLocationOrderpoint(models.Model):
 
         procurements = self._build_procurements(procurement_data)
         if not procurements:
-            return result
+            return self._after_replenishment(replenishment_moves)
 
-        result = self._execute_run_procurements(procurements)
-        return self._after_replenishment(result)
+        replenishment_moves = self._execute_run_procurements(procurements)
+        return self._after_replenishment(replenishment_moves)
 
     # -------------------------------------------------------------------------
     # Replenishment execution pipeline (orderpoint-bound)

--- a/stock_location_orderpoint/models/stock_location_orderpoint.py
+++ b/stock_location_orderpoint/models/stock_location_orderpoint.py
@@ -380,6 +380,8 @@ class StockLocationOrderpoint(models.Model):
         computer = self.env["stock.location.replenishment.computer"].new(
             self._prepare_replenishment_computer_values()
         )
+        computer = computer.with_context(orderpoint_id=self.id)
+        # computer.location_id = computer.location_id.with_context(orderpoint_id=self.id)
         computer._strategy = self._strategy_model
         return computer
 
@@ -387,7 +389,7 @@ class StockLocationOrderpoint(models.Model):
         """Prepare the values to instantiate the replenishment computer."""
         self.ensure_one()
         return {
-            "location_id": self.location_id.id,
+            "location_id": self.location_id.with_context(orderpoint_id=self.id),
             "location_src_id": self.location_src_id.id,
             "horizon": self._horizon_datetime,
             "replenish_limit_to_free_qty": self.replenish_limit_to_free_qty,
@@ -432,34 +434,6 @@ class StockLocationOrderpoint(models.Model):
         self.ensure_one()
         return (self.priority, self.location_id.id, product_id)
 
-    def _reclaim_replenishing_moves_from_lower_priority_orderpoints(self):
-        """Reassign existing replenishing moves from lower-priority orderpoints to this one.
-
-        Ensures higher-priority orderpoints inherit existing moves and bump their priority
-        instead of being ignored by the procurement engine.
-        """
-        self.ensure_one()
-        consumed_products_ids = [
-            x["product_id"]
-            for x in self.env["stock.move"].search_read(
-                self._get_consuming_moves_domain(), ["product_id"], load=None
-            )
-        ]
-        replenishment_moves = self.env["stock.move"].search(
-            [
-                ("location_orderpoint_id", "not in", [False, self.id]),
-                ("location_dest_id", "=", self.location_id.id),
-                ("priority", "<", self.priority),
-                ("product_id", "in", consumed_products_ids),
-                ("state", "not in", ("cancel", "done", "draft")),
-            ]
-        )
-        for move in replenishment_moves:
-            move.location_orderpoint_id = self.id
-            move.origin += f"/{self.name}"
-            move.name = self.name
-        return replenishment_moves
-
     def _run_replenishment(self, products=None, processed=None, job_logs=None):
         """
         Internal pipeline:
@@ -487,9 +461,7 @@ class StockLocationOrderpoint(models.Model):
         self.ensure_one()
         is_delayed = self._must_delay_fulfill_procurement()
         products = self._get_candidate_products(products)
-        replenishment_moves = (
-            self._reclaim_replenishing_moves_from_lower_priority_orderpoints()
-        )
+        replenishment_moves = self.env["stock.move"]
 
         # Filter out products already handled by a higher-priority orderpoint
         # sharing the same location. Only meaningful in the async path.

--- a/stock_location_orderpoint/models/stock_location_replenishment_computer.py
+++ b/stock_location_orderpoint/models/stock_location_replenishment_computer.py
@@ -80,7 +80,9 @@ class StockLocationReplenishmentComputer(models.TransientModel):
 
     @_strategy.setter
     def _strategy(self, value):
-        self.__strategy = value
+        self.__strategy = value.with_context(
+            orderpoint_id=self.env.context.get("orderpoint_id")
+        )
 
     @property
     def location(self):
@@ -145,8 +147,11 @@ class StockLocationReplenishmentComputer(models.TransientModel):
         :return: dict {product_id: demand_qty}
         """
         self.ensure_one()
-        if self.excluded_location_domain:
-            if products is not None:
+        if products is not None:
+            products = products.with_context(
+                orderpoint_id=self.env.context.get("orderpoint_id")
+            )
+            if self.excluded_location_domain:
                 products = products.with_context(
                     excluded_location_domain=self.excluded_location_domain
                 )

--- a/stock_location_orderpoint/tests/common.py
+++ b/stock_location_orderpoint/tests/common.py
@@ -188,9 +188,19 @@ class TestLocationOrderpointCommon(BaseCommon):
     @classmethod
     def _get_replenishment_move(cls, orderpoints, product=None):
         product = product or cls.product
+
+        # Check if origin contains **any** of the orderpoint names
+        # (necessary in case of merged moves)
+        origin_domain = []
+        names = orderpoints.mapped("name")
+        if names:
+            origin_domain = ["|"] * (len(names) - 1)
+            for name in names:
+                origin_domain.append(("origin", "ilike", name))
+
         return cls.env["stock.move"].search(
-            [
-                ("origin", "in", orderpoints.mapped("name")),
+            origin_domain
+            + [
                 ("product_id", "=", product.id),
                 ("state", "!=", "cancel"),
             ]

--- a/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
@@ -296,3 +296,44 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
         # trigger creation of first orderpoint repl move
         manual_orderpoint_2.run_replenishment()
         self._assert_replenishment_move(repl_move, 40, manual_orderpoint_2)
+
+    def test_orderpoint_priority_reassignment_on_shared_replenishment(self):
+        product = self.product
+        orderpoint_1, replenish_loc_1 = self._create_orderpoint_complete(
+            "Replenish Area 1",
+            trigger="manual",
+            replenish_method="fill_up",
+            proc_run_async=False,
+        )
+        orderpoint_2, replenish_loc_2 = self._create_orderpoint_complete(
+            "Replenish Area 2",
+            trigger="manual",
+            replenish_method="fill_up",
+            priority="1",
+            proc_run_async=False,
+        )
+
+        # Set inventory on replenishment locations
+        for repl_loc in [replenish_loc_1, replenish_loc_2]:
+            self.env["stock.quant"].with_context(inventory_mode=True).create(
+                {
+                    "product_id": product.id,
+                    "location_id": repl_loc.id,
+                    "inventory_quantity": 50.0,
+                }
+            )._apply_inventory()
+
+        out_move = self._create_outgoing_move(11, orderpoint_1.location_id, product)
+        self._run_replenishment(orderpoint_1)
+        out_move._action_cancel()
+
+        replenish_move_1 = self._get_replenishment_move(orderpoint_1, product)
+        self.assertEqual(replenish_move_1.product_uom_qty, 11.0)
+        self.assertEqual(replenish_move_1.priority, "0")
+
+        # Create a need that is already covered by the existing repl move
+        self._create_outgoing_move(2, orderpoint_2.location_id, product)
+        self._run_replenishment(orderpoint_2)
+        replenish_move_2 = self._get_replenishment_move(orderpoint_2, product)
+        self.assertEqual(replenish_move_1, replenish_move_2)
+        self.assertEqual(replenish_move_2.priority, "1")

--- a/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
+++ b/stock_location_orderpoint/tests/test_location_orderpoint_priority.py
@@ -299,22 +299,22 @@ class TestLocationOrderpointPriority(TestLocationOrderpointCommon):
 
     def test_orderpoint_priority_reassignment_on_shared_replenishment(self):
         product = self.product
-        orderpoint_1, replenish_loc_1 = self._create_orderpoint_complete(
-            "Replenish Area 1",
-            trigger="manual",
-            replenish_method="fill_up",
-            proc_run_async=False,
-        )
-        orderpoint_2, replenish_loc_2 = self._create_orderpoint_complete(
-            "Replenish Area 2",
-            trigger="manual",
-            replenish_method="fill_up",
-            priority="1",
-            proc_run_async=False,
+        self.env.cr.execute(
+            """
+                    ALTER TABLE stock_location_orderpoint
+                    DROP CONSTRAINT stock_location_orderpoint_location_route_unique;
+                    """
         )
 
+        (orderpoint_1, replenish_loc_1,) = self._create_orderpoint_complete(
+            "Reserve",
+            trigger="manual",
+            proc_run_async=False,
+        )
+        orderpoint_2 = orderpoint_1.copy({"priority": "1"})
+
         # Set inventory on replenishment locations
-        for repl_loc in [replenish_loc_1, replenish_loc_2]:
+        for repl_loc in [replenish_loc_1]:
             self.env["stock.quant"].with_context(inventory_mode=True).create(
                 {
                     "product_id": product.id,


### PR DESCRIPTION
When running replenishment for a higher-priority orderpoint after a lower-priority
one, existing replenishment moves covering actual demand were
causing the procurement engine to skip updating the necessary moves.